### PR TITLE
New sync locking mechanism

### DIFF
--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -1357,15 +1357,15 @@ void set_htotal(uint16_t htotal) {
 
   // hbst (memory) should always start before or exactly at hbst (display) for interlaced sources to look nice
   // .. at least in PAL modes. NTSC doesn't seem to be affected
-  uint16_t h_blank_start_position = (uint16_t)((htotal * (32.0f / 45.0f)) + 1) & 0xfffe;
+  uint16_t h_blank_start_position = (uint16_t)(((uint32_t) htotal * 32) / 45 + 1) & 0xfffe;
   uint16_t h_blank_stop_position =  0;  //(uint16_t)htotal;  // it's better to use 0 here, allows for easier masking
-  uint16_t h_sync_start_position =  (uint16_t)((htotal * (172.0f / 225.0f)) + 1) & 0xfffe;
-  uint16_t h_sync_stop_position =   (uint16_t)((htotal * (62.0f / 75.0f)) + 1) & 0xfffe;
+  uint16_t h_sync_start_position =  (uint16_t)(((uint32_t) htotal * 172) / 225 + 1) & 0xfffe;
+  uint16_t h_sync_stop_position =   (uint16_t)(((uint32_t) htotal * 62) / 75 + 1) & 0xfffe;
 
   // Memory fetch locations should somehow be calculated with settings for line length in IF and/or buffer sizes in S4 (Capture Buffer)
   // just use something that works for now
   uint16_t h_blank_memory_start_position = h_blank_start_position - 1;
-  uint16_t h_blank_memory_stop_position =  (uint16_t)htotal * (41.0f / 45.0f);
+  uint16_t h_blank_memory_stop_position =  (uint16_t)(((uint32_t) htotal * 41) / 45);
 
   writeOneByte(0xF0, 3);
 
@@ -1425,10 +1425,10 @@ void set_vtotal(uint16_t vtotal) {
   // VS start: 961 / 1000 = (961/1000)
   // VS stop : 964 / 1000 = (241/250)
 
-  uint16_t v_blank_start_position = vtotal * (24.0f / 25.0f);
+  uint16_t v_blank_start_position = ((uint32_t) vtotal * 24) / 25;
   uint16_t v_blank_stop_position = vtotal;
-  uint16_t v_sync_start_position = vtotal * (961.0f / 1000.0f);
-  uint16_t v_sync_stop_position = vtotal * (241.0f / 250.0f);
+  uint16_t v_sync_start_position = ((uint32_t) vtotal * 961) / 1000;
+  uint16_t v_sync_stop_position = ((uint32_t) vtotal * 241) / 250;
 
   // write vtotal
   writeOneByte(0xF0, 3);
@@ -1584,7 +1584,7 @@ void aquireSyncLock() {
   Serial.print(F(" Start HTotal: ")); Serial.println(htotal);
 
   // start looking at an htotal value at or slightly below anticipated target
-  htotal = ((float)(htotal) / (float)(outputLength)) * (float)(inputLength);
+  htotal = ((uint32_t)htotal * inputLength) / outputLength;
 
   uint8_t attempts = 40;
   while (attempts-- > 0) {

--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -116,23 +116,6 @@ void writeBytes(uint8_t slaveRegister, uint8_t* values, int numValues)
   writeBytes(GBS_ADDR, slaveRegister, values, numValues);
 }
 
-void writeProgramArray(const uint8_t* programArray)
-{
-  for (int y = 0; y < 6; y++)
-  {
-    writeOneByte(0xF0, (uint8_t)y );
-    for (int z = 0; z < 16; z++)
-    {
-      uint8_t bank[16];
-      for (int w = 0; w < 16; w++)
-      {
-        bank[w] = pgm_read_byte(programArray + (y * 256 + z * 16 + w));
-      }
-      writeBytes(z * 16, bank, 16);
-    }
-  }
-}
-
 void writeProgramArrayNew(const uint8_t* programArray)
 {
   int index = 0;
@@ -277,95 +260,6 @@ void writeProgramArrayNew(const uint8_t* programArray)
 // S1_00 - S1_2a "IF"
 // S3_00 - S3_74 "VDS"
 //
-
-// This is still sometimes useful:
-void writeProgramArraySection(const uint8_t* programArray, byte section, byte subsection = 0) {
-  // section 1: index = 48
-  uint8_t bank[16];
-  int index = 0;
-
-  if (section == 0) {
-    index = 0;
-    writeOneByte(0xF0, 0);
-    for (int j = 0; j <= 1; j++) { // 2 times
-      for (int x = 0; x <= 15; x++) {
-        bank[x] = pgm_read_byte(programArray + index);
-        index++;
-      }
-      writeBytes(0x40 + (j * 16), bank, 16);
-    }
-    for (int x = 0; x <= 15; x++) {
-      bank[x] = pgm_read_byte(programArray + index);
-      index++;
-    }
-    writeBytes(0x90, bank, 16);
-  }
-  if (section == 1) {
-    index = 48;
-    writeOneByte(0xF0, 1);
-    for (int j = 0; j <= 8; j++) { // 9 times
-      for (int x = 0; x <= 15; x++) {
-        bank[x] = pgm_read_byte(programArray + index);
-        index++;
-      }
-      writeBytes(j * 16, bank, 16);
-    }
-  }
-  if (section == 2) {
-    index = 192;
-    writeOneByte(0xF0, 2);
-    for (int j = 0; j <= 3; j++) { // 4 times
-      for (int x = 0; x <= 15; x++) {
-        bank[x] = pgm_read_byte(programArray + index);
-        index++;
-      }
-      writeBytes(j * 16, bank, 16);
-    }
-  }
-  if (section == 3) {
-    index = 256;
-    writeOneByte(0xF0, 3);
-    for (int j = 0; j <= 7; j++) { // 8 times
-      for (int x = 0; x <= 15; x++) {
-        bank[x] = pgm_read_byte(programArray + index);
-        index++;
-      }
-      writeBytes(j * 16, bank, 16);
-    }
-  }
-  if (section == 4) {
-    index = 384;
-    writeOneByte(0xF0, 4);
-    for (int j = 0; j <= 5; j++) { // 6 times
-      for (int x = 0; x <= 15; x++) {
-        bank[x] = pgm_read_byte(programArray + index);
-        index++;
-      }
-      writeBytes(j * 16, bank, 16);
-    }
-  }
-  if (section == 5) {
-    index = 480;
-    int j = 0;
-    if (subsection == 1) {
-      index = 512;
-      j = 2;
-    }
-    writeOneByte(0xF0, 5);
-    for (; j <= 6; j++) {
-      for (int x = 0; x <= 15; x++) {
-        bank[x] = pgm_read_byte(programArray + index);
-        if (index == 482) { // s5_02 bit 6+7 = input selector (only 6 is relevant)
-          if (rto->inputIsYpBpR)bitClear(bank[x], 6);
-          else bitSet(bank[x], 6);
-        }
-        index++;
-      }
-      writeBytes(j * 16, bank, 16);
-    }
-    resetPLL(); resetPLLAD();// only for section 5
-  }
-}
 
 void fuzzySPWrite() {
   writeOneByte(0xF0, 5);

--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -116,9 +116,17 @@ void writeBytes(uint8_t slaveRegister, uint8_t* values, int numValues)
   writeBytes(GBS_ADDR, slaveRegister, values, numValues);
 }
 
+void copyBank(uint8_t* bank, const uint8_t* programArray, uint16_t* index)
+{
+  for (uint8_t x = 0; x < 16; ++x) {
+    bank[x] = pgm_read_byte(programArray + *index);
+    (*index)++;
+  }
+}
+
 void writeProgramArrayNew(const uint8_t* programArray)
 {
-  int index = 0;
+  uint16_t index = 0;
   uint8_t bank[16];
 
   // programs all valid registers (the register map has holes in it, so it's not straight forward)
@@ -157,45 +165,30 @@ void writeProgramArrayNew(const uint8_t* programArray)
           }
           writeBytes(0x40 + (j * 16), bank, 16);
         }
-        for (int x = 0; x <= 15; x++) {
-          bank[x] = pgm_read_byte(programArray + index);
-          index++;
-        }
+        copyBank(bank, programArray, &index);
         writeBytes(0x90, bank, 16);
         break;
       case 1:
         for (int j = 0; j <= 8; j++) { // 9 times
-          for (int x = 0; x <= 15; x++) {
-            bank[x] = pgm_read_byte(programArray + index);
-            index++;
-          }
+          copyBank(bank, programArray, &index);
           writeBytes(j * 16, bank, 16);
         }
         break;
       case 2:
         for (int j = 0; j <= 3; j++) { // 4 times
-          for (int x = 0; x <= 15; x++) {
-            bank[x] = pgm_read_byte(programArray + index);
-            index++;
-          }
+          copyBank(bank, programArray, &index);
           writeBytes(j * 16, bank, 16);
         }
         break;
       case 3:
         for (int j = 0; j <= 7; j++) { // 8 times
-          for (int x = 0; x <= 15; x++) {
-            bank[x] = pgm_read_byte(programArray + index);
-            index++;
-          }
+          copyBank(bank, programArray, &index);
           writeBytes(j * 16, bank, 16);
         }
         break;
       case 4:
         for (int j = 0; j <= 5; j++) { // 6 times
-          for (int x = 0; x <= 15; x++) {
-            bank[x] = pgm_read_byte(programArray + index);
-            index++;
-          }
+          copyBank(bank, programArray, &index);
           writeBytes(j * 16, bank, 16);
         }
         break;


### PR DESCRIPTION
This is not 100% ready, but I want to get feedback on it.  It prevents tearing artifacts with my Sega Genesis.

------------------------

Use new sync locking technique

This requires a hardware change: the input csync signal must be
connected to an analog input pin.

The input and output vsync pulses are phase locked by constantly
adjusting the size of the vertical front porch.  The output is locked
to trail the input so that it never "catches up" with the capture
buffer being filled by the deinterlacer, which would result in a
screen tear.