### PR TITLE
Add fast digital pin read function

### DIFF
--- a/fastpin.h
+++ b/fastpin.h
@@ -1,0 +1,11 @@
+#include <pins_arduino.h>
+
+static inline uint8_t volatile* portToInput(uint8_t port) {
+    return reinterpret_cast<uint8_t volatile*>(port_to_input_PGM[port]);
+}
+
+template <uint8_t Pin>
+static inline bool fastRead() {
+    return (*portToInput(digital_pin_to_port_PGM[Pin]) &
+            digital_pin_to_bit_mask_PGM[Pin]);
+}

--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -53,6 +53,8 @@ extern "C" {
 #include <ArduinoOTA.h>
 #endif
 
+#include "fastpin.h"
+
 #include "debug.h"
 
 #include "tv5725.h"
@@ -1414,23 +1416,23 @@ void initSyncLock() {
 // Sample vsync start and stop times (for two consecutive frames) from debug pin
 bool vsyncInputSample(unsigned long* start, unsigned long* stop) {
   unsigned long timeoutStart = micros();
-  while (digitalRead(debugInPin))
+  while (fastRead<debugInPin>())
     if (micros() - timeoutStart >= syncTimeout)
       return false;
-  while (!digitalRead(debugInPin))
+  while (!fastRead<debugInPin>())
     if (micros() - timeoutStart >= syncTimeout)
       return false;
   *start = micros();
-  while (digitalRead(debugInPin))
+  while (fastRead<debugInPin>())
     if (micros() - timeoutStart >= syncTimeout)
       return false;
-  while (!digitalRead(debugInPin))
+  while (!fastRead<debugInPin>())
     if (micros() - timeoutStart >= syncTimeout)
       return false;
-  while (digitalRead(debugInPin))
+  while (fastRead<debugInPin>())
     if (micros() - timeoutStart >= syncTimeout)
       return false;
-  while (!digitalRead(debugInPin))
+  while (!fastRead<debugInPin>())
     if (micros() - timeoutStart >= syncTimeout)
       return false;
   *stop = micros();
@@ -1440,17 +1442,17 @@ bool vsyncInputSample(unsigned long* start, unsigned long* stop) {
 // Sample vsync start and stop times from output vsync pin
 bool vsyncOutputSample(unsigned long* start, unsigned long* stop) {
   unsigned long timeoutStart = micros();
-  while (digitalRead(vsyncInPin))
+  while (fastRead<vsyncInPin>())
     if (micros() - timeoutStart >= syncTimeout)
       return false;
-  while (!digitalRead(vsyncInPin))
+  while (!fastRead<vsyncInPin>())
     if (micros() - timeoutStart >= syncTimeout)
       return false;
   *start = micros();
-  while (digitalRead(vsyncInPin))
+  while (fastRead<vsyncInPin>())
     if (micros() - timeoutStart >= syncTimeout)
       return false;
-  while (!digitalRead(vsyncInPin))
+  while (!fastRead<vsyncInPin>())
     if (micros() - timeoutStart >= syncTimeout)
       return false;
   *stop = micros();
@@ -1827,8 +1829,8 @@ void setPhaseSP() {
 
   if (pulseIn(debugInPin, HIGH, 100000) != 0) {
     if  (pulseIn(debugInPin, LOW, 100000) != 0) {
-      while (digitalRead(debugInPin) == 1);
-      while (digitalRead(debugInPin) == 0);
+      while (fastRead<debugInPin>() == 1);
+      while (fastRead<debugInPin>() == 0);
     }
   }
 
@@ -1855,8 +1857,8 @@ void setPhaseADC() {
 
   if (pulseIn(debugInPin, HIGH, 100000) != 0) {
     if  (pulseIn(debugInPin, LOW, 100000) != 0) {
-      while (digitalRead(debugInPin) == 1);
-      while (digitalRead(debugInPin) == 0);
+      while (fastRead<debugInPin>() == 1);
+      while (fastRead<debugInPin>() == 0);
     }
   }
 


### PR DESCRIPTION
The hope is that the call gets optimized to a direct memory read by including the pin lookup tables directly.  Let me know if this works on the other boards you have.