### PR TITLE
Fix compile error with more recent ESP8266 toolchains

### DIFF
--- a/framesync.h
+++ b/framesync.h
@@ -145,7 +145,7 @@ private:
     if (inPeriod == 0 || outPeriod == 0) { return false; } // safety
 
     // allow ~4 negative (inPeriod is < outPeriod) clock cycles jitter 
-    if (abs(inPeriod - outPeriod) <= 4) {
+    if (max(inPeriod, outPeriod) - min(inPeriod, outPeriod) <= 4) {
       /*if (inPeriod >= outPeriod) {
         Serial.print("inPeriod >= out: ");
         Serial.println(inPeriod - outPeriod);

--- a/framesync.h
+++ b/framesync.h
@@ -145,7 +145,7 @@ private:
     if (inPeriod == 0 || outPeriod == 0) { return false; } // safety
 
     // allow ~4 negative (inPeriod is < outPeriod) clock cycles jitter 
-    if (max(inPeriod, outPeriod) - min(inPeriod, outPeriod) <= 4) {
+    if ((inPeriod > outPeriod ? inPeriod - outPeriod : outPeriod - inPeriod) <= 4) {
       /*if (inPeriod >= outPeriod) {
         Serial.print("inPeriod >= out: ");
         Serial.println(inPeriod - outPeriod);


### PR DESCRIPTION
With latest toolchains compiling fails in "framesync.h" at a position where the absolute value of the difference is calculated.

The problem with this is that both values, that are subtracted, are unsigned values. I don't know if older compilers had some workaround in place here, but this is clearly wrong. If you subtract a bigger unsigned integer from a smaller unsigned value, then this does not get negative but it will overflow and the result is clearly not what is expected here.

I've replaced this line with something that at least I think tells clearly what is meant here: "Subtract the smaller of the two variables from the bigger of the two variables".