### PR TITLE
Maintain constant latency with clock generator installed

### DIFF
--- a/framesync.h
+++ b/framesync.h
@@ -614,12 +614,13 @@ public:
         // practice.
         float correction = 0.0038f * latency_err_frames;
 
-        // Most displays can handle the difference between 60 and 59.94 FPS
-        // (ratio of 1.001) with no issue. To avoid compatibility errors, clamp
-        // the maximum deviation from input FPS to this ratio. This is
-        // sufficient as long as fpsInput does not vary drastically from frame
-        // to frame.
-        constexpr float MAX_CORRECTION = 0.001f;
+        // Some LCD displays (eg. Dell U2312HM) lose sync when changing
+        // frequency by 0.1% (switching between 59.94 and 60 FPS).
+        //
+        // To ensure long-term FPS stability, clamp the maximum deviation from
+        // input FPS to 0.06%. This is sufficient as long as fpsInput does not
+        // vary drastically from frame to frame.
+        constexpr float MAX_CORRECTION = 0.0006f;
         if (correction > MAX_CORRECTION) correction = MAX_CORRECTION;
         if (correction < -MAX_CORRECTION) correction = -MAX_CORRECTION;
 
@@ -632,8 +633,9 @@ public:
         // In case fpsInput is measured incorrectly, rawFpsOutput may be
         // drastically different from the previous frame's output FPS. To limit
         // the impact of incorrect input FPS measurements, clamp the maximum FPS
-        // deviation relative to the previous frame's *output* FPS.
-        constexpr float MAX_FPS_CHANGE = 0.001f;
+        // deviation relative to the previous frame's *output* FPS. This
+        // provides short-term FPS stability.
+        constexpr float MAX_FPS_CHANGE = 0.0006f;
         float fpsOutput = rawFpsOutput;
         fpsOutput = std::min(fpsOutput, prevFpsOutput * (1 + MAX_FPS_CHANGE));
         fpsOutput = std::max(fpsOutput, prevFpsOutput * (1 - MAX_FPS_CHANGE));

--- a/framesync.h
+++ b/framesync.h
@@ -21,7 +21,7 @@
 // FS_DEBUG_LED:  just blink LED (off = adjust phase, on = normal phase)
 //#define FS_DEBUG
 //#define FS_DEBUG_LED
-#define FRAMESYNC_DEBUG
+// #define FRAMESYNC_DEBUG
 
 namespace MeasurePeriod {
     volatile uint32_t stopTime, startTime;

--- a/framesync.h
+++ b/framesync.h
@@ -654,9 +654,9 @@ public:
 
         fsDebugPrintf(
             "periodInput=%d, fpsInput=%f, latency_err_frames=%f from %f, "
-            "fpsOutput := %f\n",
+            "fpsOutput=%f := %f\n",
             periodInput, fpsInput, latency_err_frames, (float)syncTargetPhase / 360.f,
-            fpsOutput);
+            prevFpsOutput, fpsOutput);
 
         const auto freqExtClockGen = (uint32_t)(maybeFreqExt_per_videoFps * fpsOutput);
 

--- a/framesync.h
+++ b/framesync.h
@@ -527,10 +527,14 @@ public:
         bool success = false;
         for (int attempt = 0; attempt < 2; attempt++) {
             // Measure input period and output latency.
-            if (!vsyncPeriodAndPhase(&periodInput, nullptr, &phase)) {
+            bool ret = vsyncPeriodAndPhase(&periodInput, nullptr, &phase);
+            // TODO make vsyncPeriodAndPhase() restore TEST_BUS_SEL, not the caller?
+            GBS::TEST_BUS_SEL::write(0x0);
+            if (!ret) {
                 SerialM.printf("runFrequency(): vsyncPeriodAndPhase failed, retrying...\n");
                 continue;
             }
+
             fpsInput = esp8266_clock_freq / (float)periodInput;
             if (fpsInput < 47.0f || fpsInput > 86.0f) {
                 SerialM.printf(

--- a/framesync.h
+++ b/framesync.h
@@ -527,14 +527,6 @@ public:
             return false;
         }
 
-        if (delayLock < 2) {
-            fsDebugPrintf(
-                "Skipping FrameSyncManager::runFrequency(), delayLock=%d < 2\n",
-                delayLock);
-            delayLock++;
-            return true;
-        }
-
         // ESP32 FPU only accelerates single-precision float add/mul, not divide, not double.
         // https://esp32.com/viewtopic.php?p=82090#p82090
 

--- a/framesync.h
+++ b/framesync.h
@@ -401,6 +401,34 @@ public:
 
         return true;
     }
+
+    // Perform vsync phase locking.  This is accomplished by measuring
+    // the period and phase offset of the input and output vsync
+    // signals, then adjusting the output video clock to bring the phase
+    // offset closer to the desired value.
+    static bool runFrequency()
+    {
+        int32_t period;
+        int32_t phase;
+        int32_t target;
+
+        if (!syncLockReady)
+            return false;
+
+        if (delayLock < 2) {
+            delayLock++;
+            return true;
+        }
+
+        if (!vsyncPeriodAndPhase(&period, NULL, &phase))
+            return false;
+
+        target = (syncTargetPhase * period) / 360;
+
+        // TODO see externalClockGenSyncInOutRate.
+
+        return true;
+    }
 };
 
 template <class GBS, class Attrs>

--- a/framesync.h
+++ b/framesync.h
@@ -247,7 +247,8 @@ private:
     }
 
 public:
-    // sets syncLockReady = false, which in turn starts a new findBestHtotal run in loop()
+    // sets syncLockReady = ready() = false, which in turn starts a new init()
+    // -> findBestHtotal() run in loop()
     static void reset(uint8_t frameTimeLockMethod)
     {
 #ifdef FS_DEBUG

--- a/framesync.h
+++ b/framesync.h
@@ -112,6 +112,8 @@ private:
     // difference in microseconds
     static bool vsyncPeriodAndPhase(int32_t *periodInput, int32_t *periodOutput, int32_t *phase)
     {
+        SerialM.printf("TEST_BUS_SEL=%d\n", GBS::TEST_BUS_SEL::read());
+
         uint32_t inStart, inStop, outStart, outStop;
         uint32_t inPeriod, outPeriod, diff;
 

--- a/framesync.h
+++ b/framesync.h
@@ -546,8 +546,8 @@ public:
 
             // Check that the two FPS measurements are sufficiently close.
             float diff = fabs(fpsInput2 - fpsInput);
-            // TODO switch to relative difference
-            if (diff != diff || diff > 0.5) {
+            float relDiff = diff / std::min(fpsInput, fpsInput2);
+            if (relDiff != relDiff || diff > 0.5f || relDiff > 0.00833f) {
                 SerialM.printf(
                     "FrameSyncManager::runFrequency() measured inconsistent FPS %f and %f, retrying...\n",
                     fpsInput,

--- a/framesync.h
+++ b/framesync.h
@@ -475,10 +475,18 @@ public:
             // Failed due to external factors (PAD_CKIN_ENZ=0 on
             // startup), not bad input signal, don't return frame sync
             // error.
+            #ifdef FRAMESYNC_DEBUG
+            SerialM.printf(
+                "Skipping FrameSyncManager::runFrequency(), GBS::PAD_CKIN_ENZ::read() != 0\n");
+            #endif
             return true;
         }
 
         if (rto->outModeHdBypass) {
+            #ifdef FRAMESYNC_DEBUG
+            SerialM.printf(
+                "Skipping FrameSyncManager::runFrequency(), rto->outModeHdBypass\n");
+            #endif
             return true;
         }
         if (GBS::PLL648_CONTROL_01::read() != 0x75) {
@@ -488,10 +496,20 @@ public:
             return true;
         }
 
-        if (!syncLockReady)
+        if (!syncLockReady) {
+            #ifdef FRAMESYNC_DEBUG
+            SerialM.printf(
+                "Skipping FrameSyncManager::runFrequency(), !syncLockReady\n");
+            #endif
             return false;
+        }
 
         if (delayLock < 2) {
+            #ifdef FRAMESYNC_DEBUG
+            SerialM.printf(
+                "Skipping FrameSyncManager::runFrequency(), delayLock=%d < 2\n",
+                delayLock);
+            #endif
             delayLock++;
             return true;
         }

--- a/framesync.h
+++ b/framesync.h
@@ -532,6 +532,12 @@ public:
                 continue;
             }
             fpsInput = esp8266_clock_freq / (float)periodInput;
+            if (fpsInput < 47.0f || fpsInput > 86.0f) {
+                SerialM.printf(
+                    "runFrequency(): fpsInput wrong: %f, retrying...\n",
+                    fpsInput);
+                continue;
+            }
 
             // Measure input period again. vsyncPeriodAndPhase()/getPulseTicks()
             // -> vsyncInputSample() depend on GBS::TEST_BUS_SEL = 0, but
@@ -543,6 +549,12 @@ public:
                 continue;
             }
             float fpsInput2 = esp8266_clock_freq / (float)periodInput2;
+            if (fpsInput2 < 47.0f || fpsInput2 > 86.0f) {
+                SerialM.printf(
+                    "runFrequency(): fpsInput2 wrong: %f, retrying...\n",
+                    fpsInput2);
+                continue;
+            }
 
             // Check that the two FPS measurements are sufficiently close.
             float diff = fabs(fpsInput2 - fpsInput);

--- a/framesync.h
+++ b/framesync.h
@@ -330,7 +330,7 @@ public:
     // signals and adjusting the frame size (and thus the output vsync
     // frequency) to bring the phase offset closer to the desired
     // value.
-    static bool run(uint8_t frameTimeLockMethod)
+    static bool runVsync(uint8_t frameTimeLockMethod)
     {
         int32_t period;
         int32_t phase;

--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -8597,7 +8597,7 @@ void loop()
                     GBS::TEST_BUS_SEL::write(0x0);
                 }
                 //unsigned long startTime = millis();
-                if (!FrameSync::run(uopt->frameTimeLockMethod)) {
+                if (!FrameSync::runVsync(uopt->frameTimeLockMethod)) {
                     if (rto->syncLockFailIgnore-- == 0) {
                         FrameSync::reset(uopt->frameTimeLockMethod); // in case run() failed because we lost sync signal
                     }

--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -382,9 +382,7 @@ void externalClockGenResetClock()
     if (!rto->extClockGenDetected) {
         return;
     }
-    #ifdef FRAMESYNC_DEBUG
-    SerialM.printf("externalClockGenResetClock()\n");
-    #endif
+    fsDebugPrintf("externalClockGenResetClock()\n");
 
     uint8_t activeDisplayClock = GBS::PLL648_CONTROL_01::read();
 
@@ -433,9 +431,7 @@ void externalClockGenResetClock()
 
 void externalClockGenSyncInOutRate()
 {
-    #ifdef FRAMESYNC_DEBUG
-    SerialM.printf("externalClockGenSyncInOutRate()\n");
-    #endif
+    fsDebugPrintf("externalClockGenSyncInOutRate()\n");
 
     if (!rto->extClockGenDetected) {
         return;
@@ -8604,9 +8600,7 @@ void loop()
                 GBS::TEST_BUS_SEL::write(0x0);
             }
             //unsigned long startTime = millis();
-            #ifdef FRAMESYNC_DEBUG
-            SerialM.printf("running frame sync, clock gen = %d\n", rto->extClockGenDetected);
-            #endif
+            fsDebugPrintf("running frame sync, clock gen enabled = %d\n", rto->extClockGenDetected);
             bool success = rto->extClockGenDetected
                 ? FrameSync::runFrequency()
                 : FrameSync::runVsync(uopt->frameTimeLockMethod);

--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -8589,7 +8589,9 @@ void loop()
     {
         uint16_t htotal = GBS::STATUS_SYNC_PROC_HTOTAL::read();
         uint16_t pllad = GBS::PLLAD_MD::read();
-        // SerialM.printf("htotal=%d, pllad=%d\n", htotal, pllad);
+        #ifdef FRAMESYNC_DEBUG
+        SerialM.printf("htotal=%d, pllad=%d\n", htotal, pllad);
+        #endif
 
         if (((htotal > (pllad - 3)) && (htotal < (pllad + 3)))) {
             uint8_t debug_backup = GBS::TEST_BUS_SEL::read();
@@ -8597,6 +8599,9 @@ void loop()
                 GBS::TEST_BUS_SEL::write(0x0);
             }
             //unsigned long startTime = millis();
+            #ifdef FRAMESYNC_DEBUG
+            SerialM.printf("running frame sync, clock gen = %d\n", rto->extClockGenDetected);
+            #endif
             bool success = rto->extClockGenDetected
                 ? FrameSync::runFrequency()
                 : FrameSync::runVsync(uopt->frameTimeLockMethod);

--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -8597,9 +8597,6 @@ void loop()
     {
         uint16_t htotal = GBS::STATUS_SYNC_PROC_HTOTAL::read();
         uint16_t pllad = GBS::PLLAD_MD::read();
-        #ifdef FRAMESYNC_DEBUG
-        SerialM.printf("htotal=%d, pllad=%d\n", htotal, pllad);
-        #endif
 
         if (((htotal > (pllad - 3)) && (htotal < (pllad + 3)))) {
             uint8_t debug_backup = GBS::TEST_BUS_SEL::read();

--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -382,6 +382,9 @@ void externalClockGenResetClock()
     if (!rto->extClockGenDetected) {
         return;
     }
+    #ifdef FRAMESYNC_DEBUG
+    SerialM.printf("externalClockGenResetClock()\n");
+    #endif
 
     uint8_t activeDisplayClock = GBS::PLL648_CONTROL_01::read();
 
@@ -422,6 +425,7 @@ void externalClockGenResetClock()
 
     Si.setFreq(0, rto->freqExtClockGen);
     GBS::PAD_CKIN_ENZ::write(0); // 0 = clock input enable (pin40)
+    FrameSync::clearFrequency();
 
     SerialM.print(F("clock gen reset: "));
     SerialM.println(rto->freqExtClockGen);
@@ -429,6 +433,10 @@ void externalClockGenResetClock()
 
 void externalClockGenSyncInOutRate()
 {
+    #ifdef FRAMESYNC_DEBUG
+    SerialM.printf("externalClockGenSyncInOutRate()\n");
+    #endif
+
     if (!rto->extClockGenDetected) {
         return;
     }

--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -370,7 +370,7 @@ SerialMirror SerialM;
 struct FrameSyncAttrs
 {
     static const uint8_t debugInPin = DEBUG_IN_PIN;
-    static const uint32_t lockInterval = 100 * 16.70; // every 100 frames
+    static const uint32_t lockInterval = 6 * 16.70;
     static const int16_t syncCorrection = 2;          // Sync correction in scanlines to apply when phase lags target
     static const int32_t syncTargetPhase = 90;        // Target vsync phase offset (output trails input) in degrees
                                                       // to debug: syncTargetPhase = 343 lockInterval = 15 * 16

--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -464,27 +464,7 @@ void externalClockGenSyncInOutRate()
     uint32_t current = rto->freqExtClockGen;
     FrameSync::initFrequency(ofr, old);
 
-    rto->freqExtClockGen = (sfr / ofr) * rto->freqExtClockGen;
-
-    if (current > rto->freqExtClockGen) {
-        if ((current - rto->freqExtClockGen) < 750000) {
-            while (current > rto->freqExtClockGen) {
-                current -= 1000;
-                Si.setFreq(0, current);
-                handleWiFi(0);
-            }
-        }
-    } else if (current < rto->freqExtClockGen) {
-        if ((rto->freqExtClockGen - current) < 750000) {
-            while (current < rto->freqExtClockGen) {
-                current += 1000;
-                Si.setFreq(0, current);
-                handleWiFi(0);
-            }
-        }
-    }
-
-    Si.setFreq(0, rto->freqExtClockGen);
+    setExternalClockGenFrequencySmooth((sfr / ofr) * rto->freqExtClockGen);
 
     int32_t diff = rto->freqExtClockGen - old;
 

--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -370,7 +370,7 @@ SerialMirror SerialM;
 struct FrameSyncAttrs
 {
     static const uint8_t debugInPin = DEBUG_IN_PIN;
-    static const uint32_t lockInterval = 6 * 16.70;
+    static const uint32_t lockInterval = 100 * 16.70; // every 100 frames
     static const int16_t syncCorrection = 2;          // Sync correction in scanlines to apply when phase lags target
     static const int32_t syncTargetPhase = 90;        // Target vsync phase offset (output trails input) in degrees
                                                       // to debug: syncTargetPhase = 343 lockInterval = 15 * 16

--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -458,6 +458,7 @@ void externalClockGenSyncInOutRate()
 
     uint32_t old = rto->freqExtClockGen;
     uint32_t current = rto->freqExtClockGen;
+    FrameSync::initFrequency(ofr, old);
 
     rto->freqExtClockGen = (sfr / ofr) * rto->freqExtClockGen;
 

--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -17,7 +17,6 @@
 
 #include <Wire.h>
 #include "tv5725.h"
-#include "framesync.h"
 #include "osd.h"
 
 #include "SSD1306Wire.h"
@@ -158,19 +157,6 @@ uint8_t getMovingAverage(uint8_t item)
     }
     return sum >> 4; // for array size 16
 }
-
-//
-// Sync locking tunables/magic numbers
-//
-struct FrameSyncAttrs
-{
-    static const uint8_t debugInPin = DEBUG_IN_PIN;
-    static const uint32_t lockInterval = 100 * 16.70; // every 100 frames
-    static const int16_t syncCorrection = 2;          // Sync correction in scanlines to apply when phase lags target
-    static const int32_t syncTargetPhase = 90;        // Target vsync phase offset (output trails input) in degrees
-                                                      // to debug: syncTargetPhase = 343 lockInterval = 15 * 16
-};
-typedef FrameSyncManager<GBS, FrameSyncAttrs> FrameSync;
 
 struct MenuAttrs
 {
@@ -375,6 +361,21 @@ SerialMirror SerialM;
 #else
 #define SerialM Serial
 #endif
+
+#include "framesync.h"
+
+//
+// Sync locking tunables/magic numbers
+//
+struct FrameSyncAttrs
+{
+    static const uint8_t debugInPin = DEBUG_IN_PIN;
+    static const uint32_t lockInterval = 100 * 16.70; // every 100 frames
+    static const int16_t syncCorrection = 2;          // Sync correction in scanlines to apply when phase lags target
+    static const int32_t syncTargetPhase = 90;        // Target vsync phase offset (output trails input) in degrees
+                                                      // to debug: syncTargetPhase = 343 lockInterval = 15 * 16
+};
+typedef FrameSyncManager<GBS, FrameSyncAttrs> FrameSync;
 
 void externalClockGenResetClock()
 {


### PR DESCRIPTION
This PR continuously adjusts the video output frame rate to keep video output a fixed distance (currently 1/4 frame) behind input, when "FrameTime Lock" is checked and external clock generator is installed. This fixes the bug where when a clock generator is installed, the GBS-Control would initialize input-output latency to a random value, then the latency would slowly drift over time, eventually resulting in a tear line between 0 and 1 frame old images. (Technically the initial latency is still random, but latency is reliably brought to 1/4 frame within seconds.)

The latency control algorithm used is more primitive than I described in https://github.com/ramapcsx2/gbs-control/issues/286#issuecomment-1401230470; we instead use the clock generator to offset the output frequency from the estimated input frequency, by a factor proportional to latency error (clamped to ±0.001 to avoid large frequency offsets). And I'm solely using blocking latency measurements every 100 frames (plus overhead) like your older frame sync code, rather than rewriting the code further to add continuous interrupt-driven non-blocking measurements.

But the results are surprisingly good. If you turn on `FRAMESYNC_DEBUG`, the logs show my code consistently brings latency to a steady-state of within 0.0005 (5 * 10^-4) frames of `FrameSyncAttrs::syncTargetPhase` (90 degrees = 1/4 frame behind input), starting from either console power-on, input resolution changes (240p/480i/480p), or after repeatedly changing output resolution to "480p 576p" to deliberately induce extra latency. I did not test replugging the GBS-C, but I see no reason it wouldn't work well too. I tested primarily at 480p output, but 960p output seems to work fine too.

I also measured video latency (at 480p output) by feeding the input luma signal (through a Y-splitter), and a solar panel at the top of my CRT, into the left and right channels of my my computer's audio line in, then recording at 192 KHz. This showed a latency of just over 4 milliseconds from video input to output, consistent with debug logging.

In "Pass Through" mode, frame sync is unnecessary. My logs show that it is never attempted.

This is a working prototype, but not ready for upstreaming.

## Issues

- [x] The commit history is quite messy, and the diff includes local changes, both refactors I intend to submit a PR for (if deemed acceptable), and machine-specific changes (like `compile_commands.json`, and removing `settingsMenuOLED` to simplify the code because I don't have a screen installed) that should not be merged.
	- I partly added `enum OutputMode`, which is an improvement over the original code, but I'm not confident about the variable names, and is unrelated to this fix. Ideally I'd define a similar enum for `videoStandardInput`, but I don't know the values yet.
		- Interestingly, brian-mk has also mentioned adding enums at https://github.com/ramapcsx2/gbs-control/issues/389#issuecomment-1321164339.
	- I changed the code to echo back every command you send it. I found this useful for figuring out the code that each GUI button triggers, and makes reviewing the logs after the fact more useful, since they tell you which commands you sent in what order, and at what time relative to periodic/delayed events (like sync watcher and frame time lock), input changes, and messages from the code responding to user commands.
	- I moved the existing frame sync interrupt handlers (and associated state) to `namespace MeasurePeriod`, for organization and to prepare for adding new interrupt modes like "measure frame rates and latency in background". I think this change is not harmful, but it's not a clear improvement since I didn't (yet?) implement a new "non-blocking interrupt-driven measurement" mode in a separate namespace like I had originally planned.

- [x] I have not looked into `findBestHTotal` and `applyBestHTotal` yet. I hope this will not produce a vicious cycle of GBS-C continuously increasing htotal to slow down the output frame rate, and my changes continuously increasing the video clock generator frequency to compensate. And after debugging the `FrameSyncManager::reset()` issue, I do not have the energy to learn more code.

- I noticed that the GBS-C's output at 480p is much narrower horizontally than a PC running at 640x480 DMT, or the same GBS-C runing at Pass Through output resolution hooked up to a 480p Wii (almost as wide as PC but offset horizontally). I suspect this is because the GBS-C sets its htotal value much higher relative to the horizontal active time, than the PC standard or the video input. Can this be changed to behave like Pass Through or PC DMT? Increasing the image width through the Picture Control tab/section results in the sides being corrupted.

- When I enter the Developer tab and click "HTotal--" repeatedly (from an initial value of 2345?), the image slowly gets wider. This also calls `FrameSyncManager::reset()`,  which in my initial implementation set `maybeFreqExt_per_videoFps = -1`. This caused frame sync to fail, printing `Error: trying to tune external clock frequency while clock frequency uninitialized!`. (If I press HTotal-- enough times, GBS-C triggers an automatic HTotal resync and prints `HTotal Adjust:  29` in the logs. I'm not sure what codepath triggers this, since I don't have a debugger and didn't go digging.)
	- [x] Do you use a debugger? Should I use the Arduino 1.0/2.0 IDE or VS Code for debugging, or something else?
	- I also got the `maybeFreqExt_per_videoFps < 0` error after manually clicking "Resync HTotal".
	- The error goes away when I set 480p output resolution again.

- The same "clock frequency uninitialized" error happened after power-cycling my Wii. When a video signal reappeared at the same hsync rate as before, this also called `FrameSyncManager::reset()` but not `externalClockGenSyncInOutRate()` to initialize `maybeFreqExt_per_videoFps`.
- I "fixed" this by making `FrameSyncManager::reset()` *not* clear `maybeFreqExt_per_videoFps`. I don't understand the whole state machine, but hopefully this is safe.
	- Now messing with HTotal-- and HTotal++ causes odd things to happen to input latency, where it never converges to near-zero 0.000x even after I press "Resync HTotal" (because we never call `externalClockGenSyncInOutRate` on the new output FPS). Picking an output resolution exits this odd state.
	- I still want to ensure that `FrameSyncManager` would never encounter a mismatched output resolution (I assume switching presets/resolutions always switches `rto->freqExtClockGen`) and `maybeFreqExt_per_videoFps`. To do this, I made `externalClockGenResetClock()` (which sets `rto->freqExtClockGen` when switching presets) call `FrameSync::clearFrequency()` to clear `maybeFreqExt_per_videoFps`, so `FrameSync::runFrequency()` wouldn't operate with the wrong conversion ratio for a different resolution. (`externalClockGenResetClock()` doesn't currently *measure* the output frequency produced by a given clock rate, and I didn't add it since the oscillator and TV5725 may not be stable immediately after programming a frequency.)
		- Now I get a single "clock frequency uninitialized" error when powering my console up, for a brief moment before someone (no clue who, I don't have a debugger set up) calls `externalClockGenSyncInOutRate() -> FrameSync::initFrequency()` which sets `maybeFreqExt_per_videoFps`. I'm fine with this single error, since it goes away (and frame sync begins) when the console remains powered on.
		- Ideally, in external clock generator mode, you wouldn't even call `FrameSync::runFrequency()` before `externalClockGenSyncInOutRate()`. I didn't try changing the code to make this happen.

- **I do not currently have any handling for "freak measurements".** I found that if I use Priiloader to boot straight into the HBC, then exit to the Wii Menu (Health and Safety Screen), there will be a sync phase interruption. Even with "FrameTime Lock" turned off, this usually results in a single `.` (sometimes `2 \n .`) printed to the console. What do numbers, periods, and asterisks mean after the input disappears?
- [x] With my custom "FrameTime Lock" turned on, when exiting the HBC, occasionally (in one attempt out of many) I've seen the *input* FPS be incorrectly estimated as `77.335258`, causing the video clock to be set anomalously high and my VGA CRT monitor to lose sync *after* the Health and Safety Screen appears. I'm guessing my multisync monitor synced to the GBS-C outputting 77 Hz and showed the screen, then when the GBS-C returned to 60 Hz 100 frames later, the monitor went blank before showing the screen again. **Should I fix this in this PR, or make a follow-up one** (since this PR mostly improves behavior with frametime lock turned on, and users can turn it off if they're experiencing problems)?
	- How should I handle this case? Should I save input FPS measurements, and only adjust the value by up to a factor of ±0.01 per sync iteration or 0.05-0.1 total (clamping or ignoring out-of-range values), and let the GBS-C sync watcher(?) handle resetting the output mode when the input switches between 50/60 Hz for a prolonged time?
		- Where should the cached input FPS be stored? Does the source code already save this somewhere? Should we instead derive valid FPS ranges from the input video mode?
		- When should we clear the old FPS measurement or keep it? I'm not interested in repeating the `FrameSyncManager::reset()` debugging adventure without help. Hopefully since we can always rebuild the cached FPS after a clear, it's safe to erase it in both reset() and cleanup(), whenever switching between 15 kHz, 31 kHz, or no signal, even if we don't call `externalClockGenSyncInOutRate` afterwards.
	- Should I take the median of 3 input FPS measurements (with or without rejecting values far from the expected frequency) to adjust output sync? Or if we already have a valid FPS measurement, should we instead take the median of the previous FPS and two measurements?
		- Or should I take two measurements, throw both away and take two more if they disagree by more than 1 FPS, and otherwise average them?
	- Perhaps if sync gets interrupted to the point the GBS-C outputs numbers/dots/asterisks, we should set `delayLock = 0`? I'm not sure how to do that, and it may fail to recognize sync interruptions that *don't* trigger numbers/dots/asterisks but are large enough to tamper with FPS measurements, but I still think it's worthwhile as "defense in depth" (though you have to turn it off when you test FPS measurement rather than playing games).
- If I want to take the median of multiple *sequential* vblank interval measurements, I'd have to rewrite the interrupt code to record the timestamp of multiple sequential interrupts into an array.
	- [x] Is taking multiple *sequential* vblank measurements a good idea since it's faster? Or will that increase the chance of correlated error, since a single erroneous vblank (from noise?) midway through a frame will produce *two* incorrectly low frame time measurements? Should I instead take multiple *independent* vblank interval measurements, like the time from 1-2, then 3-4 (and sleeping from 2-3 without measuring its time), using the current interrupt code?
- Additionally, taking the median of recent frame durations, on top of alternating between input and output frame time measurements, may be tricky to implement in a background interrupt handler. Perhaps you could keep a ring buffer of the last 3 measurements (and possibly the last output), and compute and output the median *within* the interrupt handler (is this too slow?).
	- [x] When writing interrupt-based code, is it safe for loop() to write to a non-volatile global variable before calling `attachInterrupt(fn)`, and `fn` to read from those non-volatile global variables once invoked by an interrupt?

- [x] How likely is it that adjusting the external clock generator within a factor of 0.001 from the frequency derived from the input FPS, will result in wildly incorrect timings (`externalClockGenResetClock()`, see `delay(1)`)? I've never seen it happen, and `externalClockGenSyncInOutRate` makes no attempt to prevent this from happening.

- [x] Will adjusting the external clock generator by a factor of ±0.001 cause monitors to lose sync or change on-screen geometry? My VGA CRT does not lose sync, and I keep thinking I see the on-screen size change, but when I look more closely I can never find it happening at the same time as frequency adjustments.

- If `runFrequency()` repeatedly fails until `syncLockFailIgnore` reaches 0, we call `FrameSync::reset()`. This currently does not reset `maybeFreqExt_per_videoFps`. This *should* be fine? But it won't bring the GBS-C out of a state where `maybeFreqExt_per_videoFps` is persistently unset by mistake.

- I added my own `FRAMESYNC_DEBUG` before noticing `FS_DEBUG`. I don't know the best course of action yet. And Ideally I'd turn off this define before this code is merged (it's useful for debugging, but clutters the logs with constant messages if you're trying to find other messages like resolution changes).

- When I check "Disable External Clock Generator", my code still uses it for latency adjustment until I click "Restart". (I also have to "Restart" after unchecking Disable, to enable the clock generator.) Is this a pre-existing bug?

## Not bugs, but room for improvement

- This does not set latency to a fixed value during start-up. I've seen latencies as high as 0.25 to 0.699 frames above the target, although these are brought down under control in a matter of seconds (and most players are interested in predictable latency during gameplay, not startup menus).

- Should we use a *lower* `FrameSyncAttrs::syncTargetPhase` (video latency)? Should we use a lower video latency when using external clock generator, than with the built-in clock? (I'm not sure if my approach handles 240p/480i transitions better than internal clock and adjusting vblank duration, though it works better in steady-state operation)
	- Ideally users could pick a runtime-configurable target phase (latency in fraction of a frame), and set it lower if they play well-behaved games, and higher when playing games that switch between 240p and 480i (most notably some PS1 games). This would require some refactoring to move phase from a template parameter to a state variable...
	- I've measured up to 0.052 frames of latency offset when switching between 240p and 480i in 240p Test Suite Wii, then waiting for the sync watcher to switch the video output rate and the frame sync to print the resulting change in phase/latency. So setting the latency target to 0.1 frames should be safe even for PS1 games.
	- Oddly sometimes the frame sync notices the FPS change *before* the sync watcher does. The resulting behavior appears harmless?

- Should we frame-sync more often (reduce `FrameSyncAttrs::lockInterval`) (though this blocks the main loop more often)? Should we wait less time after 240p/480i changes before starting frame sync (to stabilize the input latency sooner)? Currently we skip two frames, most likely due to `delayLock`.
	- I do not have the motivation to implement non-blocking frame sync, and want to get this PR (with minimal change from existing code) polished for release first.

- The current code has a separation between `framesync.h` with `FrameSyncManager` and `vsyncPeriodAndPhase` running off periods, and `gbs-control.ino` with `externalClockGenSyncInOutRate` and `getSourceFieldRate/getOutputFrameRate` running off frequencies. My current code straddles the two domains, and I feel the architectural separation makes my changes (and arguably the existing code) harder to understand.

	- For example I reference SerialM, rto, and Si in framesync.h even though they're defined in gbs-control.ino, so clangd treats these variables as undeclared identifiers. And I had to move `#include "framesync.h"` in the main file to below `SerialMirror SerialM;`.
	- Ideally I'd either merge framesync.h into the main file, or move global declarations to a `#pragma once` header and have each file include all headers it uses. And I may or may not try to unify the various methods of getting frame rates.

- I'm scared of how stateful the code is, and how easy it is to perform duplicated work, or (even worse) forget to initialize or update variables. To help find these bugs, I included multiple checks for invalid state, which print an error message. During testing, I've seen multiple cases where `FrameSyncManager::runFrequency` was called after `FrameSyncManager::reset()` cleared `FrameSyncManager::maybeFreqExt_per_videoFps`, before calling `FrameSyncManager::initFrequency()` to initialize it again, and had to think of ways (given my fragmentary understanding of GBS-C's state machine) to preserve or initialize this state when needed, and clear it when invalid.
	- In projects I maintain myself, my current strategy for keeping track is tracking all mutations in an instance of a "StateTransaction" type ([example](https://gitlab.com/exotracker/exotracker-cpp/-/blob/5e32ce834da38f3cc3334163c0ff618fadfec345/src/gui/main_window.h#L238-336)), which sets a bitflag for each piece of modified state, then recomputes all derived state in the non-noexcept destructor (you could also use an explicit commit method to avoid throwing from a destructor).
		- This approach was built primarily around user input, though it also handles periodic events like audio playback ([code](https://gitlab.com/exotracker/exotracker-cpp/-/blob/5e32ce834da38f3cc3334163c0ff618fadfec345/src/gui/main_window.cpp#L1002)). I'm not sure how well this will translate to the GBS-C where you're primarily responding to changes in input video signal, and counting valid/invalid frames before taking action.
	- Another improvement is using `std::optional<T>` and `std::variant` to add "not present" states, and force the interior type `T` to be "always valid" as long as you check that the optional is not nullopt. Then design the program (upfront or through incremental refactoring) around this simplified, more tractable, state management.

(i've spent long enough poring over my code and reading/revising this post over and over...)

Fixes #286.