### PR TITLE
Properly apply Bypass video mode from custom preset

### DIFF
--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -5014,6 +5014,7 @@ void setOutModeHdBypass()
     GBS::PA_ADC_BYPSZ::write(1); // enable phase unit ADC
     GBS::PA_SP_BYPSZ::write(1);  // enable phase unit SP
 
+    GBS::GBS_PRESET_ID::write(PresetHdBypass);
     doPostPresetLoadSteps(); // todo: remove this, code path for hdbypass is hard to follow
     resetDebugPort();
 
@@ -5248,8 +5249,7 @@ void setOutModeHdBypass()
     setAndUpdateSogLevel(rto->currentLevelSOG); // also re-latch everything
 
     rto->outModeHdBypass = 1;
-    rto->presetID = 0x21; // bypass flavor 1, used to signal buttons in web ui
-    GBS::GBS_PRESET_ID::write(0x21);
+    rto->presetID = PresetHdBypass; // bypass flavor 1, used to signal buttons in web ui
 
     unsigned long timeout = millis();
     while ((!getStatus16SpHsStable()) && (millis() - timeout < 2002)) {

--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -4258,8 +4258,6 @@ void applyPresets(uint8_t result)
                             - we never overwrite rto->presetID = PresetCustomized!
                     - ...
                     - rto->outModeHdBypass = 1; (again?!)
-                    - rto->presetID = PresetHdBypass; // bypass flavor 1, used
-                      to signal buttons in web ui
                 - rto->presetID = PresetCustomized;
         */
 
@@ -5092,6 +5090,12 @@ void setOutModeHdBypass()
 
     GBS::GBS_PRESET_ID::write(PresetHdBypass);
     doPostPresetLoadSteps(); // todo: remove this, code path for hdbypass is hard to follow
+
+    // doPostPresetLoadSteps() sets rto->presetID = GBS_PRESET_ID::read() =
+    // PresetHdBypass. Because we set rto->outModeHdBypass = 1,
+    // doPostPresetLoadSteps() skips assigning rto->presetID = PresetCustomized.
+    // Our caller must assign that manually if needed.
+
     resetDebugPort();
 
     rto->autoBestHtotalEnabled = false; // need to re-set this
@@ -5325,7 +5329,6 @@ void setOutModeHdBypass()
     setAndUpdateSogLevel(rto->currentLevelSOG); // also re-latch everything
 
     rto->outModeHdBypass = 1;
-    rto->presetID = PresetHdBypass; // bypass flavor 1, used to signal buttons in web ui
 
     unsigned long timeout = millis();
     while ((!getStatus16SpHsStable()) && (millis() - timeout < 2002)) {

--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -226,8 +226,8 @@ struct runTimeOptions
 } rtos;
 struct runTimeOptions *rto = &rtos;
 
-/// Requested output resolution, *given to* applyPresets().
-enum OutputMode : uint8_t {
+/// Output resolution requested by user, *given to* applyPresets().
+enum PresetPreference : uint8_t {
     Output960P = 0,
     Output480P = 1,
     OutputCustomized = 2,
@@ -243,7 +243,7 @@ struct userOptions
 {
     // 0 - normal, 1 - x480/x576, 2 - customized, 3 - 1280x720, 4 - 1280x1024, 5 - 1920x1080,
     // 6 - downscale, 10 - bypass
-    OutputMode presetPreference;
+    PresetPreference presetPreference;
     uint8_t presetSlot;
     uint8_t enableFrameTimeLock;
     uint8_t frameTimeLockMethod;
@@ -7328,7 +7328,7 @@ void setup()
             saveUserPrefs(); // if this fails, there must be a spiffs problem
         } else {
             //on a fresh / spiffs not formatted yet MCU:  userprefs.txt open ok //result = 207
-            uopt->presetPreference = (OutputMode)(f.read() - '0'); // #1
+            uopt->presetPreference = (PresetPreference)(f.read() - '0'); // #1
             if (uopt->presetPreference > 10)
                 uopt->presetPreference = Output960P; // fresh spiffs ?
 
@@ -8170,7 +8170,7 @@ void loop()
                 uint8_t videoMode = getVideoMode();
                 if (videoMode == 0)
                     videoMode = rto->videoStandardInput;
-                OutputMode backup = uopt->presetPreference;
+                PresetPreference backup = uopt->presetPreference;
                 uopt->presetPreference = Output720P;
                 rto->videoStandardInput = 0; // force hard reset
                 applyPresets(videoMode);


### PR DESCRIPTION
Fixes:

- Loading and saving custom preset used to produce a preset entry showing the output resolution as Custom, rather than the actual output resolution. This meant that loading and saving a preset was not a no-op.
	- ~~This PR fixes it to save the output resolution *for your current input resolution*. This makes loading and saving a preset a no-op, as long as you saved it in the same *input* resolution as the last time you saved.~~
	- Deferred to a later PR because you can't read hardware (which yields) in a HTTP callback (which must not yield), requiring more invasive code changes.
- Previously loading a custom preset containing Bypass would fail to load properly, if you hadn't already loaded Bypass in the same console power-on.
	- This PR properly reapplies Bypass when reloading custom presets which pass-through sync at the current input resolution.
- Add enum PresetID (incomplete).
- Attempt to better document how userOptions's PresetPreference controls output resolution and runTimeOptions's PresetID.

draft. applies on top of PR #415 (not yet merged), so the github diff view includes irrelevant changes. will be rebased once that's merged.

- [x] if you're comfortable, I could start pushing branches directly to this upstream repo, then I can "stack" PRs on top of each other.

todo:

- [x] merge #415
- [x] combine "Rename OutputMode back to PresetPreference" comment rewrites with commit "Add enum PresetID for derived state"
- [x] add more descriptive multi-line commit messages
- [x] test more

Fixes #416.