### PR TITLE
Fix preset slot-related bugs caused by mixing integers and characters

### DIFF
--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -238,13 +238,15 @@ enum PresetPreference : uint8_t {
     OutputBypass = 10,
 };
 
+using Ascii8 = uint8_t;
+
 // userOptions holds user preferences / customizations
 struct userOptions
 {
     // 0 - normal, 1 - x480/x576, 2 - customized, 3 - 1280x720, 4 - 1280x1024, 5 - 1920x1080,
     // 6 - downscale, 10 - bypass
     PresetPreference presetPreference;
-    uint8_t presetSlot;
+    Ascii8 presetSlot;
     uint8_t enableFrameTimeLock;
     uint8_t frameTimeLockMethod;
     uint8_t enableAutoGain;
@@ -9775,7 +9777,7 @@ const uint8_t *loadPresetFromSPIFFS(byte forVideoMode)
 {
     static uint8_t preset[432];
     String s = "";
-    uint8_t slot = 0;
+    Ascii8 slot = 0;
     File f;
 
     f = SPIFFS.open("/preferencesv2.txt", "r");
@@ -9851,7 +9853,7 @@ void savePresetToSPIFFS()
 {
     uint8_t readout = 0;
     File f;
-    uint8_t slot = 0;
+    Ascii8 slot = 0;
 
     // first figure out if the user has set a preferenced slot
     f = SPIFFS.open("/preferencesv2.txt", "r");

--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -9544,6 +9544,9 @@ void startWebserver()
                 AsyncWebParameter *slotIndexParam = request->getParam(0);
                 String slotIndexString = slotIndexParam->value();
                 uint8_t slotIndex = lowByte(slotIndexString.toInt());
+                if (slotIndex >= SLOTS_TOTAL) {
+                    goto fail;
+                }
 
                 // name param
                 AsyncWebParameter *slotNameParam = request->getParam(1);
@@ -9569,6 +9572,7 @@ void startWebserver()
             }
         }
 
+        fail:
         request->send(200, "application/json", result ? "true" : "false");
     });
 
@@ -9643,7 +9647,11 @@ void startWebserver()
             slotsBinaryFileRead.read((byte *)&slotsObject, sizeof(slotsObject));
             slotsBinaryFileRead.close();
             String slotIndexMap = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~()!*:,";
-            uint8_t currentSlot = slotIndexMap.indexOf(uopt->presetSlot);
+            auto currentSlot = slotIndexMap.indexOf(uopt->presetSlot);
+            if (currentSlot == -1) {
+                goto fail;
+            }
+
             uopt->wantScanlines = slotsObject.slot[currentSlot].scanlines;
 
             SerialM.print(F("slot: "));
@@ -9664,6 +9672,7 @@ void startWebserver()
             result = true;
         }
 
+        fail:
         request->send(200, "application/json", result ? "true" : "false");
     });
 

--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -7144,7 +7144,7 @@ void loadDefaultUserOptions()
 {
     uopt->presetPreference = Output960P;    // #1
     uopt->enableFrameTimeLock = 0; // permanently adjust frame timing to avoid glitch vertical bar. does not work on all displays!
-    uopt->presetSlot = 0;          //
+    uopt->presetSlot = 'A';          //
     uopt->frameTimeLockMethod = 0; // compatibility with more displays
     uopt->enableAutoGain = 0;
     uopt->wantScanlines = 0;

--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -7339,8 +7339,6 @@ void setup()
                 uopt->enableFrameTimeLock = 0;
 
             uopt->presetSlot = lowByte(f.read());
-            if (uopt->presetSlot >= SLOTS_TOTAL)
-                uopt->presetSlot = 0;
 
             uopt->frameTimeLockMethod = (uint8_t)(f.read() - '0');
             if (uopt->frameTimeLockMethod > 1)
@@ -9789,9 +9787,7 @@ const uint8_t *loadPresetFromSPIFFS(byte forVideoMode)
         result[2] = f.read();
 
         f.close();
-        if (result[2] < SLOTS_TOTAL) { // # of slots
-            slot = result[2];          // otherwise not stored on spiffs
-        }
+        slot = result[2];
     } else {
         // file not found, we don't know what preset to load
         SerialM.println(F("please select a preset slot first!")); // say "slot" here to make people save usersettings

--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -7603,7 +7603,8 @@ void updateWebSocketData()
     if (rto->webServerEnabled && rto->webServerStarted) {
         if (webSocket.connectedClients() > 0) {
 
-            char toSend[7] = {0};
+            constexpr size_t MESSAGE_LEN = 6;
+            char toSend[MESSAGE_LEN] = {0};
             toSend[0] = '#'; // makeshift ping in slot 0
 
             switch (rto->presetID) {
@@ -7700,7 +7701,7 @@ void updateWebSocketData()
 
             // send ping and stats
             if (ESP.getFreeHeap() > 14000) {
-                webSocket.broadcastTXT(toSend);
+                webSocket.broadcastTXT(toSend, MESSAGE_LEN);
             } else {
                 webSocket.disconnect();
             }


### PR DESCRIPTION
This PR is based around treating `uopt->presetSlot` consistently as a character rather than integer index. This approach requires the least changes to code, since it requires no changes to the web UI sending ASCII, and most (but not all) of the C++ backend already treats `uopt->presetSlot` as ASCII. Alternative approaches are also possible (see #422 @ Solutions), but are more difficult and may introduce errors due to making large untested changes, so I don't want to pursue them.

- Fix settings all appearing as disabled after factory reset
- Highlight first slot after factory reset, rather than null slot
- Add checks for invalid preset IDs/numbers in HTTP handlers
	- This fixes possibly-exploitable memory corruption bugs. There are likely more yet to be fixed, for example #421 (thanks C++ and no bounds checks).
- Add Ascii8 type for `uopt->presetSlot`, so we don't treat it as a number
	- Should this instead be marked as `char`?
	- Or do you want to leave it as `uint8_t`, and not encode "preset slots are ASCII" through the variable's type?
- Remove incorrect "bounds checks" for ASCII character in `uopt->presetSlot`
	- Fixes preset slots 8 ('H') and above not working.

Fixes #422.