### PR TITLE
Add a more robust clockgen detection algorithm

### DIFF
--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -491,19 +491,6 @@ void externalClockGenSyncInOutRate()
     delay(1);
 }
 
-void externalClockGenInitialize()
-{
-    // MHz: 27, 32.4, 40.5, 54, 64.8, 81, 108, 129.6, 162
-    rto->freqExtClockGen = 81000000;
-    if (!rto->extClockGenDetected) {
-        return;
-    }
-    Si.init(25000000L); // many Si5351 boards come with 25MHz crystal; 27000000L for one with 27MHz
-    Si.setPower(0, SIOUT_6mA);
-    Si.setFreq(0, rto->freqExtClockGen);
-    Si.disable(0);
-}
-
 void externalClockGenDetectPresence()
 {
     if (uopt->disableExternalClockGenerator) {
@@ -530,6 +517,19 @@ void externalClockGenDetectPresence()
             rto->extClockGenDetected = 1;
         }
     }
+}
+
+void externalClockGenInitialize()
+{
+    // MHz: 27, 32.4, 40.5, 54, 64.8, 81, 108, 129.6, 162
+    rto->freqExtClockGen = 81000000;
+    if (!rto->extClockGenDetected) {
+        return;
+    }
+    Si.init(25000000L); // many Si5351 boards come with 25MHz crystal; 27000000L for one with 27MHz
+    Si.setPower(0, SIOUT_6mA);
+    Si.setFreq(0, rto->freqExtClockGen);
+    Si.disable(0);
 }
 
 static inline void writeOneByte(uint8_t slaveRegister, uint8_t value)


### PR DESCRIPTION
### Background
As part of a recent gbs-control build I did, I procured an external glockgen that claimed to be an Si5351.
Upon further examination, I believe it actually utilizes a clone chip.

The clone chip does NOT replicate the reset functionality of defaulting to 11xx xxxx for the XTAL_CL register, which existing code assumes and uses for detection.

The library used for small code size for the Si5351 also doesn't write XTAL_CL as part of its init which the other small libraries do (a possible oversight?)

These two combined caused issues with this particular Si5351 board that caused it to fail detection and not run.

### Changes
Previous code read the XTAL_CL value, and assumed all non-zero values were valid as on reset it should read 11xx xxxx.
This fails as it appears the clone chip ships with XTAL_CL unconfigured.

My changes instead do the following
- echoes the detection method of the main Arduino library ([see here](https://github.com/etherkit/Si5351Arduino/blob/b516084e094309837d8f7db6e7c06eb5f8ef6637/src/si5351.cpp#L68))
- adds the XTAL_CL portion to the initialization routine

This method works for both what I assume to be an authentic chip (on an Adafruit version) and a clone chip (on some cheap Amazon listing), and my gbs-control functions with both.


