### PR TITLE
Reduce latency for frequency-based frame sync

### DIFF
--- a/framesync.h
+++ b/framesync.h
@@ -106,7 +106,8 @@ private:
 
     static const uint8_t debugInPin = Attrs::debugInPin;
     static const int16_t syncCorrection = Attrs::syncCorrection;
-    static const int32_t syncTargetPhase = Attrs::syncTargetPhase;
+    static const int32_t vsyncTargetPhase = Attrs::vsyncTargetPhase;
+    static const int32_t freqSyncTargetPhase = Attrs::freqSyncTargetPhase;
 
     static bool syncLockReady;
     static uint8_t delayLock;
@@ -418,7 +419,7 @@ public:
         if (!vsyncPeriodAndPhase(&period, NULL, &phase))
             return false;
 
-        target = (syncTargetPhase * period) / 360;
+        target = (vsyncTargetPhase * period) / 360;
 
         if (phase > target)
             correction = 0;
@@ -601,7 +602,7 @@ public:
         }
 
         // ESP CPU cycles
-        int32_t target = (syncTargetPhase * periodInput) / 360;
+        int32_t target = (freqSyncTargetPhase * periodInput) / 360;
 
         // Latency error (distance behind target), in fractional frames.
         // If latency increases, boost frequency, and vice versa.
@@ -650,7 +651,7 @@ public:
         fsDebugPrintf(
             "periodInput=%d, fpsInput=%f, latency_err_frames=%f from %f, "
             "fpsOutput=%f := %f\n",
-            periodInput, fpsInput, latency_err_frames, (float)syncTargetPhase / 360.f,
+            periodInput, fpsInput, latency_err_frames, (float)freqSyncTargetPhase / 360.f,
             prevFpsOutput, fpsOutput);
 
         const auto freqExtClockGen = (uint32_t)(maybeFreqExt_per_videoFps * fpsOutput);

--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -383,8 +383,9 @@ struct FrameSyncAttrs
     static const uint8_t debugInPin = DEBUG_IN_PIN;
     static const uint32_t lockInterval = 100 * 16.70; // every 100 frames
     static const int16_t syncCorrection = 2;          // Sync correction in scanlines to apply when phase lags target
-    static const int32_t syncTargetPhase = 90;        // Target vsync phase offset (output trails input) in degrees
+    static const int32_t vsyncTargetPhase = 90;       // Target vsync phase offset (output trails input) in degrees
                                                       // to debug: syncTargetPhase = 343 lockInterval = 15 * 16
+    static const int32_t freqSyncTargetPhase = 45;    // Target phase offset when using more precise frequency-based mode
 };
 typedef FrameSyncManager<GBS, FrameSyncAttrs> FrameSync;
 


### PR DESCRIPTION
Frequency-based framesync is more precise and doesn't drift back and forth relative to the target phase, so we can safely run it at a lower latency without risking tearing or falling a frame behind.

This should be 100% safe in regular operation in a fixed video mode, and *mostly* safe when the game switches between 240p and 480i (safe unless `externalClockGenSyncInOutRate` is called too late after a mode switch, or fails).

We allocate 0.125 frames of latency in steady state. This should be more than the (up to 0.071+ frames of) buffer we lose when input slows down from 262.5 to 263 lines, before we respond and change our output rate to match.

(This new measurement of 0.071+ frames is larger than the maximum I previously observed at https://github.com/ramapcsx2/gbs-control/pull/405#issuecomment-1407776551. Hopefully 0.125 frames of buffer is very unlikely to be exceeded; if it ever is, the appearance and input latency will suffer since we roll over to a full frame of latency and have to work our way back down.)

- [ ] Should I increase the target latency even further? Or drop this PR entirely? (If so, I'm keeping this patch locally.)
- Ideally we would make `runSyncWatcher()` respond to 240p/480i changes faster (previously researched in https://github.com/ramapcsx2/gbs-control/pull/405#issuecomment-1418912768 `timingAdjustDelay`), so we can safely reduce frame sync latency even further.
- Ideally users could reconfigure their desired target latency? Or is this too complex/esoteric to expose on the web UI, and fine as a code change?