### PR TITLE
Fix output resolution shown after loading and saving custom presets

### DIFF
--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -173,7 +173,6 @@ typedef MenuManager<GBS, MenuAttrs> Menu;
 /// Video processing mode, loaded into register GBS_PRESET_ID by applyPresets()
 /// and read to rto->presetID by doPostPresetLoadSteps(). Shown on web UI.
 enum PresetID : uint8_t {
-    PresetCustomized = 0x09,
     PresetHdBypass = 0x21,
     PresetBypassRGBHV = 0x22,
 };
@@ -194,6 +193,7 @@ struct runTimeOptions
     uint8_t continousStableCounter;
     uint8_t failRetryAttempts;
     uint8_t presetID;  // PresetID
+    bool isCustomPreset;
     uint8_t HPLLState;
     uint8_t medResLineCount;
     uint8_t osr;
@@ -959,6 +959,7 @@ void setResetParameters()
 void OutputComponentOrVGA()
 {
 
+    // TODO replace with rto->isCustomPreset?
     boolean isCustomPreset = GBS::GBS_PRESET_CUSTOM::read();
     if (uopt->wantOutputComponent) {
         SerialM.println(F("Output Format: Component"));
@@ -3294,7 +3295,7 @@ void doPostPresetLoadSteps()
         }
     }
     rto->presetID = GBS::GBS_PRESET_ID::read();
-    boolean isCustomPreset = GBS::GBS_PRESET_CUSTOM::read();
+    rto->isCustomPreset = GBS::GBS_PRESET_CUSTOM::read();
 
     GBS::ADC_UNUSED_64::write(0);
     GBS::ADC_UNUSED_65::write(0); // clear temp storage
@@ -3382,7 +3383,7 @@ void doPostPresetLoadSteps()
 
     setAndUpdateSogLevel(rto->currentLevelSOG);
 
-    if (!isCustomPreset) {
+    if (!rto->isCustomPreset) {
         setAdcParametersGainAndOffset();
     }
 
@@ -3401,10 +3402,10 @@ void doPostPresetLoadSteps()
     rto->boardHasPower = true;       //same
 
     if (rto->presetID == 0x06 || rto->presetID == 0x16) {
-        isCustomPreset = 0; // override so it applies section 2 deinterlacer settings
+        rto->isCustomPreset = 0; // override so it applies section 2 deinterlacer settings
     }
 
-    if (!isCustomPreset) {
+    if (!rto->isCustomPreset) {
         if (rto->videoStandardInput == 3 || rto->videoStandardInput == 4 ||
             rto->videoStandardInput == 8 || rto->videoStandardInput == 9) {
             GBS::IF_LD_RAM_BYPS::write(1); // 1_0c 0 no LD, do this before setIfHblankParameters
@@ -3649,7 +3650,7 @@ void doPostPresetLoadSteps()
     }
 
     if (rto->presetID == 0x06 || rto->presetID == 0x16) {
-        isCustomPreset = GBS::GBS_PRESET_CUSTOM::read(); // override back
+        rto->isCustomPreset = GBS::GBS_PRESET_CUSTOM::read(); // override back
     }
 
     resetDebugPort();
@@ -3668,7 +3669,7 @@ void doPostPresetLoadSteps()
 
     latchPLLAD(); // besthtotal reliable with this (EDTV modes, possibly others)
 
-    if (isCustomPreset) {
+    if (rto->isCustomPreset) {
         // patch in segments not covered in custom preset files (currently seg 2)
         if (rto->videoStandardInput == 3 || rto->videoStandardInput == 4 || rto->videoStandardInput == 8) {
             GBS::MADPT_Y_DELAY_UV_DELAY::write(1); // 2_17 : 1
@@ -3859,7 +3860,7 @@ void doPostPresetLoadSteps()
     }
 
     // late adjustments that require some delay time first
-    if (!isCustomPreset) {
+    if (!rto->isCustomPreset) {
         if (videoStandardInputIsPalNtscSd() && !rto->outModeHdBypass) {
             // SNES has less total lines and a slight offset (only relevant in 60Hz)
             if (GBS::VPERIOD_IF::read() == 523) {
@@ -3888,7 +3889,7 @@ void doPostPresetLoadSteps()
     resetPLLAD();             // also turns on pllad
     GBS::PLLAD_LEN::write(1); // 5_11 1
 
-    if (!isCustomPreset) {
+    if (!rto->isCustomPreset) {
         GBS::VDS_IN_DREG_BYPS::write(0); // 3_40 2 // 0 = input data triggered on falling clock edge, 1 = bypass
         GBS::PLLAD_R::write(3);
         GBS::PLLAD_S::write(3);
@@ -4064,12 +4065,9 @@ void doPostPresetLoadSteps()
     else
         SerialM.print(F("bypass"));
 
-    if (isCustomPreset) {
-        rto->presetID = PresetCustomized; // overwrite to "custom" after printing original id (for webui)
-    }
     if (rto->outModeHdBypass) {
         SerialM.print(F(" (bypass)"));
-    } else if (isCustomPreset) {
+    } else if (rto->isCustomPreset) {
         SerialM.print(F(" (custom)"));
     }
 
@@ -4147,7 +4145,10 @@ void applyPresets(uint8_t result)
     }
     rto->presetIsPalForce60 = 0;      // the default
     rto->outModeHdBypass = 0;         // the default at this stage
-    GBS::GBS_PRESET_CUSTOM::write(0); // in case it is set; will get set appropriately later
+
+    // in case it is set; will get set appropriately later in doPostPresetLoadSteps()
+    GBS::GBS_PRESET_CUSTOM::write(0);
+    rto->isCustomPreset = false;
 
     // carry over debug view if possible
     if (GBS::ADC_UNUSED_62::read() != 0x00) {
@@ -4230,10 +4231,13 @@ void applyPresets(uint8_t result)
             - Read by applyPresets() to pick an output resolution.
         - rto->presetID
             - Written by applyPresets() -> doPostPresetLoadSteps().
-            - = register GBS_PRESET_ID, unless you loaded a custom preset (then
-              = PresetCustomized).
-            - Controls which button is highlighted in the web UI
-              (updateWebSocketData() -> GBSControl.buttonMapping).
+            - = register GBS_PRESET_ID.
+        - rto->isCustomPreset
+            - Written by applyPresets() -> doPostPresetLoadSteps().
+            - = register GBS_PRESET_CUSTOM.
+        - rto->isCustomPreset and rto->presetID control which button is
+            highlighted in the web UI (updateWebSocketData() ->
+            GBSControl.buttonMapping).
 
         Control flow:
 
@@ -4247,20 +4251,22 @@ void applyPresets(uint8_t result)
             - applySavedBypassPreset():
             - If GBS_PRESET_ID == PresetHdBypass (yes):
                 - rto->videoStandardInput = result; (not sure why)
-                - setOutModeHdBypass()
+                - setOutModeHdBypass(regsInitialized=true)
                     - rto->outModeHdBypass = 1;
                     - loadHdBypassSection()
                         - Overwrites S1_30..5F.
                     - GBS::GBS_PRESET_ID::write(PresetHdBypass);
+                    - if (!regsInitialized) (false)
+                        - ~~GBS::GBS_PRESET_CUSTOM::write(0);~~ (skipped)
                     - doPostPresetLoadSteps()
                         - rto->presetID = GBS::GBS_PRESET_ID::read();
                             - PresetHdBypass
+                        - rto->isCustomPreset = GBS::GBS_PRESET_CUSTOM::read();
+                            - true
                         - Branches based on rto->presetID
                         - if (rto->outModeHdBypass) (yes) return.
-                            - we never overwrite rto->presetID = PresetCustomized!
                     - ...
                     - rto->outModeHdBypass = 1; (again?!)
-                - rto->presetID = PresetCustomized;
         */
 
         uint8_t rawPresetId = GBS::GBS_PRESET_ID::read();
@@ -4270,9 +4276,6 @@ void applyPresets(uint8_t result)
 
             // Setup video mode passthrough.
             setOutModeHdBypass(true);
-
-            // Highlight the "custom" button in the web UI.
-            rto->presetID = PresetCustomized;
             return true;
         }
         if (rawPresetId == PresetBypassRGBHV) {
@@ -5100,9 +5103,7 @@ void setOutModeHdBypass(bool regsInitialized)
     doPostPresetLoadSteps(); // todo: remove this, code path for hdbypass is hard to follow
 
     // doPostPresetLoadSteps() sets rto->presetID = GBS_PRESET_ID::read() =
-    // PresetHdBypass. Because we set rto->outModeHdBypass = 1,
-    // doPostPresetLoadSteps() skips assigning rto->presetID = PresetCustomized.
-    // Our caller must assign that manually if needed.
+    // PresetHdBypass, and rto->isCustomPreset = GBS_PRESET_CUSTOM::read().
 
     resetDebugPort();
 
@@ -7261,6 +7262,7 @@ void setup()
     rto->phaseSP = 16;
     rto->failRetryAttempts = 0;
     rto->presetID = 0;
+    rto->isCustomPreset = false;
     rto->HPLLState = 0;
     rto->motionAdaptiveDeinterlaceActive = false;
     rto->deinterlaceAutoEnabled = true;
@@ -7613,7 +7615,9 @@ void updateWebSocketData()
             char toSend[MESSAGE_LEN] = {0};
             toSend[0] = '#'; // makeshift ping in slot 0
 
-            switch (rto->presetID) {
+            if (rto->isCustomPreset) {
+                toSend[1] = '9';
+            } else switch (rto->presetID) {
                 case 0x01:
                 case 0x11:
                     toSend[1] = '1';
@@ -7637,9 +7641,6 @@ void updateWebSocketData()
                 case 0x06:
                 case 0x16:
                     toSend[1] = '6';
-                    break;
-                case PresetCustomized: // custom
-                    toSend[1] = '9';
                     break;
                 case PresetHdBypass: // bypass 1
                 case PresetBypassRGBHV: // bypass 2


### PR DESCRIPTION
(This writeup may not be 100% accurate. I'm creating this PR weeks after my initial commit, and discovered numerous errors in my original commit message, so I had to reword those messages. There may be errors in this writeup as well.)

# Initialize `GBS_PRESET_CUSTOM` in setOutModeHdBypass 

I found that `GBS_PRESET_CUSTOM` was left uninitialized (keeps old value) when switching *into* bypass mode. This means that switching from a fixed resolution to Bypass left it at 0, and switching from a custom preset to Bypass left it at 1. This may or may not affect auto gain behavior; I have not checked, but this inconsistent behavior is worth fixing anyway.

To avoid issues, make `setOutModeHdBypass()` set `GBS_PRESET_CUSTOM` to 0. But don't do this if `applyPresets()` is loading a custom preset, has set `GBS_PRESET_CUSTOM` to 1, and is calling `setOutModeHdBypass(regsInitialized=true)` to apply the saved "bypass" preset.

(This really belongs in a separate PR, but I got a merge conflict trying to remove this commit from this PR, and I'm worried about introducing new bugs when disentangling the code.)

# Fix output resolution shown after loading and saving custom presets

Change the code to set `rto->isCustomPreset = GBS_PRESET_CUSTOM::read()`, and not set `rto->presetID` to 9.

Why was this done? Loading a custom preset writes the "effective preset ID" to the GBS_PRESET_ID register. Previously it would set `rto->presetID` to 9 rather than `GBS_PRESET_ID`, so the web UI (`updateWebSocketData()`) can highlight the "load preset" button to indicate a preset was loaded.

Saving the preset again (in the HTTP "/slot/save" handler) writes `rto->presetID` (=9) to `SlotMeta::presetID`. This causes the web UI to show the preset slot's output resolution as "Custom", which is not useful.

## Fix

We cannot make "/slot/save" read the `GBS_PRESET_ID` register rather than `rto->presetID`, because reading registers over I2C requires calling `yield()`, and the current (terrible) AsyncWebServer does not allow calling `yield()` from HTTP callbacks.

Instead we make `rto->presetID` always reflect `GBS_PRESET_ID` (and never be set to 9). "/slot/save" reads only `rto->presetID` when writing the resolution metadata of a saved preset.

- One alternative is to create a `rto->presetIdReal` variable, keep assigning `rto->presetId = {9,PresetCustomized}` in `doPostPresetLoadSteps`, and only read `rto->presetIdReal` in "/slot/save" or when necessary.
	- This alternative *might* result in less code side effects, since presumably there *might* be some code *relying* on `doPostPresetLoadSteps()` setting `rto->presetID = 9`.
- Currently there is no code which checks for `rto->presetID {==,!=} {PresetCustomized,9,0x09}`, but there *might* be code which depends on `rto->presetID` not being a regular value (as opposed to "/slot/save" depending on it *being* a regular value).
- On the other hand, there might be code (`activeFrameTimeLockInitialSteps`?, `printVideoTimings`, `runSyncWatcher`?, `settingsMenuOLED`) which are *fixed* by not setting `rto->presetID = {9,PresetCustomized}`.

How do we fix the web UI? We cannot make `updateWebSocketData()` highlight "load preset" if `uopt->presetPreference == OutputCustomized`. This is because clicking a custom slot in the web UI (HTTP /slot/set) sets `uopt->presetPreference = OutputCustomized`, but doesn't call `applyPresets()` until you click "load preset" (user command '3'). Prior to actually loading the custom preset, if we're on a fixed resolution and `GBS_PRESET_CUSTOM` is 0, we need to highlight the fixed resolution's button (and ignore `uopt->presetPreference == OutputCustomized`).

To fix the web UI, we create a new variable `rto->isCustomPreset` mirroring `GBS_PRESET_CUSTOM`. Then `updateWebSocketData()` reads `rto->isCustomPreset` to decide whether to highlight "load preset" in the web UI.

- I'm not sure if this code interacts correctly with the OLED menu, or if the old code did so either. Specifically `if (oled_menuItem == 4 && oled_subsetFrame == 1)` sets `rto->presetID = GBS::GBS_PRESET_ID::read()` without actually loading a different preset. This would previously cause the web UI to stop highlighting "load preset" even when a custom preset was loaded, but will no longer do so.

## Future work

In the future, we could also change the WebSockets protocol to independently transmit the output resolution (and whether it's customized), and the current preset slot if `uopt->presetPreference == OutputCustomized`.

If different input resolutions are mapped to *different* output resolutions (for example mapping 480i input to 480p output, and 480p input to Bypass), the web UI still only shows the output resolution for the *most recently saved* input resolution, not the *current* one. But this is a smaller problem than before.