### PR TITLE
Fix warnings in libraries

### DIFF
--- a/src/WebSocketsServer.cpp
+++ b/src/WebSocketsServer.cpp
@@ -464,6 +464,7 @@ bool WebSocketsServer::newClient(WEBSOCKETS_NETWORK_CLASS * TCPclient) {
 #if(WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP8266) || (WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP8266_ASYNC) || (WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP32)
             IPAddress ip = client->tcp->remoteIP();
             DEBUG_WEBSOCKETS("[WS-Server][%d] new client from %d.%d.%d.%d\n", client->num, ip[0], ip[1], ip[2], ip[3]);
+            (void) ip;
 #else
             DEBUG_WEBSOCKETS("[WS-Server][%d] new client\n", client->num);
 #endif

--- a/src/si5351mcu.h
+++ b/src/si5351mcu.h
@@ -140,26 +140,26 @@ class Si5351mcu {
         //
         // declared as static, since they do not reference any this-> class attributes
         //
-        static void     i2cWrite( const uint8_t reg, const uint8_t val );
-        static uint8_t  i2cWriteBurst( const uint8_t start_register, const uint8_t *data, const uint8_t numbytes );
-        static int16_t  i2cRead( const uint8_t reg );
-        
-        inline const bool isEnabled( const uint8_t channel ) {
+        static void     i2cWrite( uint8_t reg, uint8_t val );
+        static uint8_t  i2cWriteBurst( uint8_t start_register, const uint8_t *data, uint8_t numbytes );
+        static int16_t  i2cRead( uint8_t reg );
+
+        inline bool isEnabled( const uint8_t channel ) {
           return channel < SICHANNELS && clkOn[ channel ] != 0;
         };
-        
-        inline const uint8_t getPower( const uint8_t channel ) {
-          return channel < SICHANNELS ? clkpower[ channel ] : 0;  
+
+        inline uint8_t getPower( const uint8_t channel ) {
+          return channel < SICHANNELS ? clkpower[ channel ] : 0;
         };
 
-        inline const uint32_t getXtalBase( void ) {
+        inline uint32_t getXtalBase( void ) {
           return base_xtal;
         };
 
-        inline const uint32_t getXtalCurrent( void ) {
+        inline uint32_t getXtalCurrent( void ) {
           return int_xtal;
         };
-        
+
 };
 
 

--- a/src/si5351mcu.md
+++ b/src/si5351mcu.md
@@ -1,0 +1,1 @@
+Si5351 0.7.1 (https://github.com/pavelmc/Si5351mcu/commit/cbbd8067e9c8e35ca2b9c886c2c97d8d553c97ed), modified to fix compiler warnings.


### PR DESCRIPTION
Fix warning in WebSocketsServer.cpp, and many warnings introduced when updating Si5351mcu in #435.

I cannot reproduce the si5351mcu.cpp bit-shift warnings in Godbolt, but they appear when building gbs-control in Arduino, using both the recommended v2.6.3 esp8266 SDK with old GCC, and the latest 3.1.1 SDK (somehow the folder is named `3.1.0-gcc10.3-e5f9fec` and not 3.1.1).

Godbolt test:

```cpp
#include <stdint.h>

int main() {
    uint8_t x[] = {
        0x0100 >> 8,
    };
    (void)x;
}
```

- [ ] Upstream warning fixes to Si5351mcu?

This also removes a pile of trailing whitespace from the vendored Si5351mcu library, since my editor strips whitespace on saving. I'm not sure whether to upstream this change or not. The main project is free of trailing whitespace, but this library has inconsistent trailing whitespace (but not *consistent* indentation on empty lines).

## Future

There remains one warning from `~/Arduino/libraries/esp8266-oled-ssd1306-master/src/SSD1306Wire.h`, but this one lives in an external library's header included by gbs-control.ino, and cannot be solved without teaching Arduino's build system to expose library header paths using `-isystem` to silence warnings from there.