### PR TITLE
Fix auto gain on passthrough, properly preserve or reset gain when loading new presets

### DIFF
--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -7953,12 +7953,10 @@ void loop()
                 SerialM.print(F("auto gain "));
                 if (uopt->enableAutoGain == 0) {
                     uopt->enableAutoGain = 1;
-                    if (!rto->outModeHdBypass) { // no readout possible
-                        GBS::ADC_RGCTRL::write(0x48);
-                        GBS::ADC_GGCTRL::write(0x48);
-                        GBS::ADC_BGCTRL::write(0x48);
-                        GBS::DEC_TEST_ENABLE::write(1);
-                    }
+                    GBS::ADC_RGCTRL::write(0x48);
+                    GBS::ADC_GGCTRL::write(0x48);
+                    GBS::ADC_BGCTRL::write(0x48);
+                    GBS::DEC_TEST_ENABLE::write(1);
                     SerialM.println("on");
                 } else {
                     uopt->enableAutoGain = 0;

--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -3285,6 +3285,8 @@ uint32_t getPllRate()
     return retVal;
 }
 
+#define AUTO_GAIN_INIT 0x48
+
 void doPostPresetLoadSteps()
 {
     //unsigned long postLoadTimer = millis();
@@ -3725,9 +3727,9 @@ void doPostPresetLoadSteps()
     // auto ADC gain
     if (uopt->enableAutoGain == 1 && adco->r_gain == 0) {
         //SerialM.println(F("ADC gain: reset"));
-        GBS::ADC_RGCTRL::write(0x48);
-        GBS::ADC_GGCTRL::write(0x48);
-        GBS::ADC_BGCTRL::write(0x48);
+        GBS::ADC_RGCTRL::write(AUTO_GAIN_INIT);
+        GBS::ADC_GGCTRL::write(AUTO_GAIN_INIT);
+        GBS::ADC_BGCTRL::write(AUTO_GAIN_INIT);
         GBS::DEC_TEST_ENABLE::write(1);
     } else if (uopt->enableAutoGain == 1 && adco->r_gain != 0) {
         GBS::ADC_RGCTRL::write(adco->r_gain);
@@ -5503,9 +5505,9 @@ void bypassModeSwitch_RGBHV()
 
     if (uopt->enableAutoGain == 1 && adco->r_gain == 0) {
         //SerialM.println("ADC gain: reset");
-        GBS::ADC_RGCTRL::write(0x48);
-        GBS::ADC_GGCTRL::write(0x48);
-        GBS::ADC_BGCTRL::write(0x48);
+        GBS::ADC_RGCTRL::write(AUTO_GAIN_INIT);
+        GBS::ADC_GGCTRL::write(AUTO_GAIN_INIT);
+        GBS::ADC_BGCTRL::write(AUTO_GAIN_INIT);
         GBS::DEC_TEST_ENABLE::write(1);
     } else if (uopt->enableAutoGain == 1 && adco->r_gain != 0) {
         /*SerialM.println("ADC gain: keep previous");
@@ -7953,9 +7955,9 @@ void loop()
                 SerialM.print(F("auto gain "));
                 if (uopt->enableAutoGain == 0) {
                     uopt->enableAutoGain = 1;
-                    GBS::ADC_RGCTRL::write(0x48);
-                    GBS::ADC_GGCTRL::write(0x48);
-                    GBS::ADC_BGCTRL::write(0x48);
+                    GBS::ADC_RGCTRL::write(AUTO_GAIN_INIT);
+                    GBS::ADC_GGCTRL::write(AUTO_GAIN_INIT);
+                    GBS::ADC_BGCTRL::write(AUTO_GAIN_INIT);
                     GBS::DEC_TEST_ENABLE::write(1);
                     SerialM.println("on");
                 } else {

--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -3725,17 +3725,19 @@ void doPostPresetLoadSteps()
     GBS::ADC_TA_05_CTRL::write(0x02); // 5_05
 
     // auto ADC gain
-    if (uopt->enableAutoGain == 1 && adco->r_gain == 0) {
-        //SerialM.println(F("ADC gain: reset"));
-        GBS::ADC_RGCTRL::write(AUTO_GAIN_INIT);
-        GBS::ADC_GGCTRL::write(AUTO_GAIN_INIT);
-        GBS::ADC_BGCTRL::write(AUTO_GAIN_INIT);
-        GBS::DEC_TEST_ENABLE::write(1);
-    } else if (uopt->enableAutoGain == 1 && adco->r_gain != 0) {
-        GBS::ADC_RGCTRL::write(adco->r_gain);
-        GBS::ADC_GGCTRL::write(adco->g_gain);
-        GBS::ADC_BGCTRL::write(adco->b_gain);
-        GBS::DEC_TEST_ENABLE::write(1);
+    if (uopt->enableAutoGain == 1) {
+        if (adco->r_gain == 0) {
+            //SerialM.println(F("ADC gain: reset"));
+            GBS::ADC_RGCTRL::write(AUTO_GAIN_INIT);
+            GBS::ADC_GGCTRL::write(AUTO_GAIN_INIT);
+            GBS::ADC_BGCTRL::write(AUTO_GAIN_INIT);
+            GBS::DEC_TEST_ENABLE::write(1);
+        } else {
+            GBS::ADC_RGCTRL::write(adco->r_gain);
+            GBS::ADC_GGCTRL::write(adco->g_gain);
+            GBS::ADC_BGCTRL::write(adco->b_gain);
+            GBS::DEC_TEST_ENABLE::write(1);
+        }
     } else {
         GBS::DEC_TEST_ENABLE::write(0); // no need for decimation test to be enabled
     }

--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -3318,6 +3318,20 @@ void doPostPresetLoadSteps()
 {
     //unsigned long postLoadTimer = millis();
 
+    // adco->r_gain gets applied if uopt->enableAutoGain is set.
+    if (uopt->enableAutoGain) {
+        if (uopt->presetPreference == OutputCustomized) {
+            // Loaded custom preset, we want to keep newly loaded gain. Save
+            // gain written by loadPresetFromSPIFFS -> writeProgramArrayNew.
+            adco->r_gain = GBS::ADC_RGCTRL::read();
+            adco->g_gain = GBS::ADC_GGCTRL::read();
+            adco->b_gain = GBS::ADC_BGCTRL::read();
+        } else {
+            // Loaded fixed preset. Keep adco->r_gain from before overwriting
+            // registers.
+        }
+    }
+
     //GBS::PAD_SYNC_OUT_ENZ::write(1);  // no sync out
     //GBS::DAC_RGBS_PWDNZ::write(0);    // no DAC
     //GBS::SFTRST_MEM_FF_RSTZ::write(0);  // mem fifos keep in reset
@@ -4402,13 +4416,6 @@ void applyPresets(uint8_t result)
         bypassModeSwitch_RGBHV();
         // don't go through doPostPresetLoadSteps
         return;
-    }
-
-    // get auto gain prefs
-    if (uopt->presetPreference == 2 && uopt->enableAutoGain) {
-        adco->r_gain = GBS::ADC_RGCTRL::read();
-        adco->g_gain = GBS::ADC_GGCTRL::read();
-        adco->b_gain = GBS::ADC_BGCTRL::read();
     }
 
     rto->videoStandardInput = result;


### PR DESCRIPTION
- [x] Verify correct behavior when loading fixed/custom scaling/passthrough resolutions with auto gain off/on

Tentative test cases:

- With auto gain off, applying fixed scaling should set gain to 0x7B.
- With auto gain off, applying fixed passthrough should set gain to 0x7B.
- With auto gain off, applying custom scaling should apply saved gain.
- With auto gain off, applying custom passthrough should apply saved gain.

And:

- With auto gain on, applying fixed scaling should preserve current gain.
- With auto gain on, applying fixed passthrough should preserve current gain.
- With auto gain on, applying custom scaling should apply saved gain.
- With auto gain on, applying custom passthrough should apply saved gain.

(All verified on Wii 480p input, as of commit fc6acc109fb2bd54941be9127562e8da01d69eb5.)

## Fixes

- Previously enabling auto gain on fixed/custom passthrough would not initialize the gain registers to clipping, and did not enable `DEC_TEST_ENABLE`. This would result in auto gain failing if it was off previously, but working if you switched from scaling to fixed/custom passthrough with auto gain already on.
- Previously, enabling auto gain on a dark scene (so auto gain doesn't reduce gain), then applying a fixed scaling resolution, would set gain to a stale value from the most recent auto gain operation, rather than the current gain. This behavior was unpredictable and confusing.

## Unresolved questions

- [x] An earlier version of this PR would reset auto gain to 0x48 when applying fixed presets. Perhaps it makes more sense to preserve fixed gain across applying fixed resolutions (like current behavior), but reliably and without the chance of loading stale values?
	- Does it make sense for fixed resolutions to reset fixed gain but carry over auto gain? (shrug, preserve existing behavior)
- [ ] Does this increase, decrease, or not affect #449? I haven't gotten any sync drops recently, but this is with quite limited testing, and I haven't swapped capacitors yet.

I'm getting sporadic black screen flashes (so far Super Monkey Ball 2 and Mario Kart Wii, with 480p pixel fix enabled but ineffective) when playing Wii in 480p, with this PR in custom passthrough mode with auto gain enabled. I don't currently know what configurations cause this problem to appear or not.

- [ ] I'll do more testing and see if it still appears with auto gain disabled, then replacing my SoG capacitors once they arrive, and if that doesn't work try 960p upscaling instead, or test *without* this PR (though if that works, then disabling auto gain should've worked already).