### PR TITLE
Skip overwriting slots.bin if we fail to read the existing contents

### DIFF
--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -9560,7 +9560,11 @@ void startWebserver()
                 File slotsBinaryFileRead = SPIFFS.open(SLOTS_FILE, "r");
 
                 if (slotsBinaryFileRead) {
-                    slotsBinaryFileRead.read((byte *)&slotsObject, sizeof(slotsObject));
+                    auto read = slotsBinaryFileRead.read((byte *)&slotsObject, sizeof(slotsObject));
+                    if (read < sizeof(slotsObject)) {
+                        Serial.print("Failed to read " SLOTS_FILE "!");
+                        goto fail;
+                    }
                     slotsBinaryFileRead.close();
                 } else {
                     File slotsBinaryFileWrite = SPIFFS.open(SLOTS_FILE, "w");


### PR DESCRIPTION
Hopefully should guard against slots.bin corruption when the GBS-C crashes.

I haven't actually seen reading slots.bin fail since adding this check. I'll merge it if it happens and prevents corruption.

Do we trust SPIFFS at all?