### PR TITLE
Properly darken chroma along with luma when enabling scanlines

### DIFF
--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -5646,7 +5646,7 @@ void enableScanlines()
         GBS::MADPT_UVDLY_PD_ST::write(0);     // 2_39 4..7
         GBS::MADPT_EN_UV_DEINT::write(1);     // 2_3a 0
         GBS::MADPT_UV_MI_DET_BYPS::write(1);  // 2_3a 7 enables 2_3b adjust
-        GBS::MADPT_UV_MI_OFFSET::write(0x40); // 2_3b 0x40 for mix, 0x00 to test
+        GBS::MADPT_UV_MI_OFFSET::write(uopt->scanlineStrength); // 2_3b offset (mixing factor here)
         GBS::MADPT_MO_ADP_UV_EN::write(1);    // 2_16 5 (try to do this some other way?)
 
         GBS::DIAG_BOB_PLDY_RAM_BYPS::write(0); // 2_00 7 enabled, looks better
@@ -9390,9 +9390,10 @@ void handleType2Command(char argument)
             }
             if (rto->scanlinesEnabled) {
                 GBS::MADPT_Y_MI_OFFSET::write(uopt->scanlineStrength);
+                GBS::MADPT_UV_MI_OFFSET::write(uopt->scanlineStrength);
             }
             saveUserPrefs();
-            SerialM.print(F("Scanline Strength: "));
+            SerialM.print(F("Scanline Brightness: "));
             SerialM.println(uopt->scanlineStrength, HEX);
             break;
         case 'Z':

--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -5642,12 +5642,12 @@ void enableScanlines()
         //GBS::RFF_ENABLE::write(0); //GBS::WFF_ENABLE::write(0);
 
         // following lines set up UV deinterlacer (on top of normal Y)
-        //GBS::MADPT_UVDLY_PD_SP::write(0);     // 2_39 0..3
-        //GBS::MADPT_UVDLY_PD_ST::write(0);     // 2_39 4..7
-        //GBS::MADPT_EN_UV_DEINT::write(1);     // 2_3a 0
-        //GBS::MADPT_UV_MI_DET_BYPS::write(1);  // 2_3a 7 enables 2_3b adjust
-        //GBS::MADPT_UV_MI_OFFSET::write(0x40); // 2_3b 0x40 for mix, 0x00 to test
-        //GBS::MADPT_MO_ADP_UV_EN::write(1);    // 2_16 5 (try to do this some other way?)
+        GBS::MADPT_UVDLY_PD_SP::write(0);     // 2_39 0..3
+        GBS::MADPT_UVDLY_PD_ST::write(0);     // 2_39 4..7
+        GBS::MADPT_EN_UV_DEINT::write(1);     // 2_3a 0
+        GBS::MADPT_UV_MI_DET_BYPS::write(1);  // 2_3a 7 enables 2_3b adjust
+        GBS::MADPT_UV_MI_OFFSET::write(0x40); // 2_3b 0x40 for mix, 0x00 to test
+        GBS::MADPT_MO_ADP_UV_EN::write(1);    // 2_16 5 (try to do this some other way?)
 
         GBS::DIAG_BOB_PLDY_RAM_BYPS::write(0); // 2_00 7 enabled, looks better
         GBS::MADPT_PD_RAM_BYPS::write(0);      // 2_24 2
@@ -5674,13 +5674,13 @@ void disableScanlines()
         //SerialM.println("disableScanlines())");
         GBS::MAPDT_VT_SEL_PRGV::write(1);
 
-        //// following lines set up UV deinterlacer (on top of normal Y)
-        //GBS::MADPT_UVDLY_PD_SP::write(4); // 2_39 0..3
-        //GBS::MADPT_UVDLY_PD_ST::write(4); // 2_39 4..77
-        //GBS::MADPT_EN_UV_DEINT::write(0);     // 2_3a 0
-        //GBS::MADPT_UV_MI_DET_BYPS::write(0);  // 2_3a 7 enables 2_3b adjust
-        //GBS::MADPT_UV_MI_OFFSET::write(4);    // 2_3b
-        //GBS::MADPT_MO_ADP_UV_EN::write(0);    // 2_16 5
+        // following lines set up UV deinterlacer (on top of normal Y)
+        GBS::MADPT_UVDLY_PD_SP::write(4); // 2_39 0..3
+        GBS::MADPT_UVDLY_PD_ST::write(4); // 2_39 4..77
+        GBS::MADPT_EN_UV_DEINT::write(0);     // 2_3a 0
+        GBS::MADPT_UV_MI_DET_BYPS::write(0);  // 2_3a 7 enables 2_3b adjust
+        GBS::MADPT_UV_MI_OFFSET::write(4);    // 2_3b
+        GBS::MADPT_MO_ADP_UV_EN::write(0);    // 2_16 5
 
         GBS::DIAG_BOB_PLDY_RAM_BYPS::write(1); // 2_00 7
         GBS::VDS_W_LEV_BYPS::write(1);         // brightness

--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -1848,10 +1848,9 @@ void dumpRegisters(byte segment)
             }
             break;
         case 2:
-            // not needed anymore, code kept for debug
-            /*for (int x = 0x0; x <= 0x3F; x++) {
-      printReg(2, x);
-    }*/
+            for (int x = 0x0; x <= 0x3F; x++) {
+                printReg(2, x);
+            }
             break;
         case 3:
             for (int x = 0x0; x <= 0x7F; x++) {


### PR DESCRIPTION
Fixes an issue where scanlines were only applied to luma and not chroma, causing blue (and somewhat red) areas of the image failing to apply scanlines.

<details>
<summary>Note to self</summary>

```
crt monitor/gbs-c scanlines, deinterlacing.md # 2023-10-30 chroma fix
```

</details>

## Background

Scanlines in 240p content are implemented by turning on the deinterlacer (but not RAM accesses?) to weave the current field with a black "previous field", then setting the deinterlacer into a mode where you manually control (using `MADPT_Y_MI_OFFSET` and `MADPT_UV_MI_OFFSET`) how much to interpolate between scanlines vs. using the previous black field.

Previously, only luma deinterlacing was enabled, and chroma was wholly interpolated between scanlines. This caused increased color saturation (and brightness if some RGB channels become negative and get clipped to zero) in scanline gaps.

## Enabling chroma scanlines

This PR enables chroma deinterlacing (which was largely implemented but commented out). The commented-out code set `MADPT_UV_MI_OFFSET` (chroma blending/brightness) to a fixed value of 64, which caused chroma to remain partly blended between scanlines even when scanlines were fully set to black, by clicking "scanline intensity" until `MADPT_Y_MI_OFFSET` (luma blending/brightness) is set to 0.

- While doing slow-motion camera testing (`PXL_20231030_115142583.mp4`), I did not find any change in latency in 240p Test Suite between scanlines on and off (either way, after pressing a button to navigate a menu, there's 1 frame of no response, and the next frame had proper luma and chroma).
	- I did notice that the first frame's colors appeared to be slightly desaturated compared to the second, so I performed more testing:
- When switching between a white and blue screen (`PXL_20231030_115938855.mp4`), proper scanlines also appeared to appear immediately on the first blue frame, without blue light appearing in the gaps of the image.

## Tuning chroma scanlines

I want the RGB values in scanline gaps to be linearly interpolated between black and the average of the adjacent scanlines. To do this, we must interpolate Y and UV by the same amount between black and the average of the adjacent scanlines. This can be achieved by setting `MADPT_UV_MI_OFFSET = MADPT_Y_MI_OFFSET` (which is itself written with `GBS::MADPT_Y_MI_OFFSET::write(uopt->scanlineStrength)`).

To verify I took pictures of my VGA CRT in 480p (which can resolve _output_ scanlines) using a macro camera, to check that scanlines appeared correctly:

- If `MADPT_UV_MI_OFFSET` is always set to 0, then with bright scanlines (`MADPT_Y_MI_OFFSET = 50`) green areas of the image have gray scanline gaps with all RGB phosphors illuminated (when they should be green), because chroma is zero but luma is nonzero:

![DSC00947](https://github.com/ramapcsx2/gbs-control/assets/913957/a571ac47-4d16-4e2d-a6df-40d21df53f5e)

- If `MADPT_UV_MI_OFFSET` is always set to 64 (like in the commented-out code), then with dark scanlines (`MADPT_Y_MI_OFFSET = 0`) blue areas of the image have blue scanline gaps (when they should be black), because luma is zero but chroma is nonzero (red/green are negative and clipped to zero):

![DSC00942 brightened](https://github.com/ramapcsx2/gbs-control/assets/913957/6e7d655a-e919-4a01-a657-aeff17bae871)

- This PR sets `MADPT_UV_MI_OFFSET` equal to `MADPT_Y_MI_OFFSET = uopt->scanlineStrength`. I verified that scanline gaps (red, green, and blue) are always the same color (but dimmer) than scanlines when brightness (the intensity button) is set to 50, and black when brightness is set to 0.

![DSC00948 compressed](https://github.com/ramapcsx2/gbs-control/assets/913957/1d304ed6-6d30-4358-8613-28088a04ece9)
![DSC00955 brightened](https://github.com/ramapcsx2/gbs-control/assets/913957/0f6abd7e-4b11-47e1-b140-5a27fefb73a4)

## Questions

- [ ] Is it safe to "Print deinterlacing registers in 'd' register dumps"? It was helpful for this PR, and I don't know why it was disabled to begin with (to reduce the dump length slightly?). Also I don't think register dumps are something a normal user ever does.
- [ ] I renamed the printed message `Scanline Strength: {MADPT_Y_MI_OFFSET}` (which never matched the "intensity" button) to `Scanline Brightness`.
	- I prefer `Scanline Brightness`because higher values correspond to higher brightness. The old name `Scanline Strength` implied that higher values produce stronger scanlines (when they actually produce weaker scanlines and gaps). Is this an acceptable name? (I tried `Scanline Bloom` which is more technically correct, but found the name too confusing for myself.)
- [ ] I'm not sure all the code I uncommented is "good". In particular, the final line `GBS::MADPT_MO_ADP_UV_EN::write(1);    // 2_16 5 (try to do this some other way?)` sounds concerning, is this badly designed? It *seems* to work?

Fixes #458.