### PR TITLE
Updated to use ESP Async WebServer v3+ API

### DIFF
--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -9542,7 +9542,7 @@ void startWebserver()
             //Serial.print("got serial request params: ");
             //Serial.println(params);
             if (params > 0) {
-                AsyncWebParameter *p = request->getParam(0);
+                const AsyncWebParameter *p = request->getParam((size_t) 0);
                 //Serial.println(p->name());
                 serialCommand = p->name().charAt(0);
 
@@ -9561,7 +9561,7 @@ void startWebserver()
             //Serial.print("got user request params: ");
             //Serial.println(params);
             if (params > 0) {
-                AsyncWebParameter *p = request->getParam(0);
+                const AsyncWebParameter *p = request->getParam((size_t) 0);
                 //Serial.println(p->name());
                 userCommand = p->name().charAt(0);
             }
@@ -9623,7 +9623,7 @@ void startWebserver()
             int params = request->params();
 
             if (params > 0) {
-                AsyncWebParameter *slotParam = request->getParam(0);
+                const AsyncWebParameter *slotParam = request->getParam((size_t) 0);
                 String slotParamValue = slotParam->value();
                 char slotValue[2];
                 slotParamValue.toCharArray(slotValue, sizeof(slotValue));
@@ -9670,7 +9670,7 @@ void startWebserver()
                 }
 
                 // index param
-                AsyncWebParameter *slotIndexParam = request->getParam(0);
+                const AsyncWebParameter *slotIndexParam = request->getParam((size_t) 0);
                 String slotIndexString = slotIndexParam->value();
                 uint8_t slotIndex = lowByte(slotIndexString.toInt());
                 if (slotIndex >= SLOTS_TOTAL) {
@@ -9678,7 +9678,7 @@ void startWebserver()
                 }
 
                 // name param
-                AsyncWebParameter *slotNameParam = request->getParam(1);
+                const AsyncWebParameter *slotNameParam = request->getParam((size_t) 1);
                 String slotName = slotNameParam->value();
 
                 char emptySlotName[25] = "                        ";
@@ -9708,7 +9708,7 @@ void startWebserver()
     server.on("/slot/remove", HTTP_GET, [](AsyncWebServerRequest *request) {
         bool result = false;
         int params = request->params();
-        AsyncWebParameter *p = request->getParam(0);
+        const AsyncWebParameter *p = request->getParam((size_t) 0);
         char param = p->name().charAt(0);
         if (params > 0)
         {
@@ -9803,7 +9803,7 @@ void startWebserver()
         if (ESP.getFreeHeap() > 10000) {
             int params = request->params();
             if (params > 0) {
-                request->send(SPIFFS, request->getParam(0)->value(), String(), true);
+                request->send(SPIFFS, request->getParam((size_t) 0)->value(), String(), true);
             } else {
                 request->send(200, "application/json", "false");
             }

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,17 +11,16 @@
 lib_dir = ./src/
 src_dir = ./
 
-[env:d1_mini]
-platform = espressif8266@2.6.3
-board = d1_mini
+[env]
+platform = espressif8266@4.2.1
 framework = arduino
 board_build.f_cpu = 160000000L
 board_build.ldscript = eagle.flash.4m1m.ld
 upload_speed = 921600
 monitor_speed = 115200
 lib_deps =  
-    me-no-dev/ESPAsyncTCP@^1.2.2
-    me-no-dev/ESP Async WebServer@^1.2.3
+    ESP32Async/ESPAsyncTCP@^2.0.0
+    ESP32Async/ESPAsyncWebServer@^3.6.2
     thingpulse/ESP8266 and ESP32 OLED driver for SSD1306 displays@4.4.0
     bluemurder/ESP8266-ping@^2.0.1
     ;r-downing/PersWiFiManager@^3.0.1
@@ -31,3 +30,9 @@ build_src_filter =
   +<**/*.cpp>
   +<**/*.ino>
   -<./3rdparty/*>
+
+[env:d1_mini]
+board = d1_mini
+
+[env:esp12e]
+board = esp12e


### PR DESCRIPTION
The returned parameter values are const and need to be indexed using size_t not the implicit int type.

This might be reverse compatible with the v2 API, but I haven't tested that. I also haven't done testing of every API endpoint, but all of the logical flows look unaffected by making the returned parameter `const`.

I see the large PR https://github.com/ramapcsx2/gbs-control/pull/551 which removes ESP Async WebServer, but hope this small change will be useful to allow users to compile with the up-to-date library. There's also a documentation update for the wiki which should be done as the two ESP Async libaries have moved repos, I'll open a PR and link it to this one.

This was tested with Arduino 2.3.4, ESP8266 board package 3.1.2, ESP Async TCP [0b6de755](https://github.com/ESP32Async/ESPAsyncTCP/commit/243bd5950f1e3b52e83265e6520618ff0b6de755), and ESP Async WebServer [v3.6.2](https://github.com/ESP32Async/ESPAsyncWebServer/releases/tag/v3.6.2).

ESP Async TCP is frozen and will not be further developed according to the maintainer as the ESP8266 is considered mature.