### PR TITLE
Turn off OLED instead of screensaver

### DIFF
--- a/OLEDMenuManager.cpp
+++ b/OLEDMenuManager.cpp
@@ -370,9 +370,11 @@ void OLEDMenuManager::tick(OLEDMenuNav nav)
     unsigned long curMili = millis();
     if (nav == OLEDMenuNav::IDLE) {
         if (curMili - lastKeyPressedTime > OLED_MENU_SCREEN_SAVER_KICK_IN_SECONDS * 1000) {
-            if (curMili - screenSaverLastUpdateTime > OLED_MENU_SCREEN_SAVER_REFRESH_INTERVAL_IN_MS) {
-                drawScreenSaver();
-                screenSaverLastUpdateTime = curMili;
+            // if (curMili - screenSaverLastUpdateTime > OLED_MENU_SCREEN_SAVER_REFRESH_INTERVAL_IN_MS) {
+            //    drawScreenSaver();
+            //    screenSaverLastUpdateTime = curMili;
+            if (!(this->displayOff)) {
+              this->turnDisplayOff();
             }
             return;
         } else if (curMili - this->lastUpdateTime < OLED_MENU_REFRESH_INTERVAL_IN_MS) {
@@ -383,12 +385,21 @@ void OLEDMenuManager::tick(OLEDMenuNav nav)
     }
     switch (nav) {
         case OLEDMenuNav::UP:
+            if (this->displayOff) {
+              this->turnDisplayOn();
+            }
             prevItem();
             break;
         case OLEDMenuNav::DOWN:
+            if (this->displayOff) {
+              this->turnDisplayOn();
+            }
             nextItem();
             break;
         case OLEDMenuNav::ENTER:
+            if (this->displayOff) {
+              this->turnDisplayOn();
+            }
             if (itemUnderCursor) {
                 enterItem(itemUnderCursor, OLEDMenuNav::IDLE, true);
             } else {

--- a/OLEDMenuManager.h
+++ b/OLEDMenuManager.h
@@ -43,6 +43,7 @@ private:
     const uint8_t *font;
     char statusBarBuffer[16];
     bool disabled;
+    bool displayOff;
     friend void setup();
 
     void resetScroll();
@@ -137,10 +138,23 @@ public:
     void disable()
     {
         this->disabled = true;
+        this->display->displayOff();
     }
     void enable()
     {
         this->disabled = false;
+        this->display->displayOn();
+    }
+
+    void turnDisplayOff()
+    {
+        this->displayOff = true;
+        this->display->displayOff();
+    }
+    void turnDisplayOn()
+    {
+        this->displayOff = false;
+        this->display->displayOn();
     }
 };
 #endif

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# gbs-control
+# gbs-control for Checkmate Monitors
+
+**This is a modification of the gbs-control firmware, containing specific changes that were made with the [Checkmate Retro Monitor](https://checkmate1500plus.com/IntroductionDisplays.aspx) in mind.**
+
+***Please be aware that some changes made may be detrimental when used with other GBS-Control compatible hardware, as some of the tunings made are dialed in quite hard according to the capability of Appy's Retro Scalar - which is the GBS-Control scaler module for the Checkmate monitor.***
 
 Documentation: https://ramapcsx2.github.io/gbs-control/
 

--- a/framesync.h
+++ b/framesync.h
@@ -106,7 +106,8 @@ private:
 
     static const uint8_t debugInPin = Attrs::debugInPin;
     static const int16_t syncCorrection = Attrs::syncCorrection;
-    static const int32_t syncTargetPhase = Attrs::syncTargetPhase;
+    static const int32_t vsyncTargetPhase = Attrs::vsyncTargetPhase;
+    static const int32_t freqSyncTargetPhase = Attrs::freqSyncTargetPhase;
 
     static bool syncLockReady;
     static uint8_t delayLock;
@@ -418,7 +419,7 @@ public:
         if (!vsyncPeriodAndPhase(&period, NULL, &phase))
             return false;
 
-        target = (syncTargetPhase * period) / 360;
+        target = (vsyncTargetPhase * period) / 360;
 
         if (phase > target)
             correction = 0;
@@ -601,7 +602,7 @@ public:
         }
 
         // ESP CPU cycles
-        int32_t target = (syncTargetPhase * periodInput) / 360;
+        int32_t target = (freqSyncTargetPhase * periodInput) / 360;
 
         // Latency error (distance behind target), in fractional frames.
         // If latency increases, boost frequency, and vice versa.
@@ -650,7 +651,7 @@ public:
         fsDebugPrintf(
             "periodInput=%d, fpsInput=%f, latency_err_frames=%f from %f, "
             "fpsOutput=%f := %f\n",
-            periodInput, fpsInput, latency_err_frames, (float)syncTargetPhase / 360.f,
+            periodInput, fpsInput, latency_err_frames, (float)freqSyncTargetPhase / 360.f,
             prevFpsOutput, fpsOutput);
 
         const auto freqExtClockGen = (uint32_t)(maybeFreqExt_per_videoFps * fpsOutput);

--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -383,8 +383,9 @@ struct FrameSyncAttrs
     static const uint8_t debugInPin = DEBUG_IN_PIN;
     static const uint32_t lockInterval = 100 * 16.70; // every 100 frames
     static const int16_t syncCorrection = 2;          // Sync correction in scanlines to apply when phase lags target
-    static const int32_t syncTargetPhase = 90;        // Target vsync phase offset (output trails input) in degrees
+    static const int32_t vsyncTargetPhase = 90;       // Target vsync phase offset (output trails input) in degrees
                                                       // to debug: syncTargetPhase = 343 lockInterval = 15 * 16
+    static const int32_t freqSyncTargetPhase = 45;    // Target phase offset when using more precise frequency-based mode
 };
 typedef FrameSyncManager<GBS, FrameSyncAttrs> FrameSync;
 

--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -4776,7 +4776,8 @@ void updateSpDynamic(boolean withCurrentVideoModeCheck)
                 //Serial.print(" (debug) ignoreBase: 0x");  Serial.println(ignoreLength,HEX);
                 uint16_t pllDiv = GBS::PLLAD_MD::read();
                 ignoreLength = ignoreLength + (pllDiv * (ratioHs * 0.38)); // for factor: crtemudriver tests
-                //SerialM.print(" (debug) ign.length: 0x"); SerialM.println(ignoreLength, HEX);
+                //SerialM.print(" (debug) ign.length: 0x");
+                SerialM.println(ignoreLength, HEX);
 
                 // > check relies on sync instability (potentially from too large ign. length) getting cought earlier
                 if (ignoreLength > GBS::SP_H_PULSE_IGNOR::read() || GBS::SP_H_PULSE_IGNOR::read() >= 0x90) {


### PR DESCRIPTION
Turns off the OLED instead of displaying the 'Press Any Key' animated message, when the screensaver time period elapses.