### PR TITLE
Update to wifi settings not saving with ESP8266 board package 3.0+

### DIFF
--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -9574,6 +9574,8 @@ void startWebserver()
             request->beginResponse(200, "application/json", "true");
         request->send(response);
 
+        WiFi.persistent(true);
+
         if (request->arg("n").length()) {     // n holds ssid
             if (request->arg("p").length()) { // p holds password
                 // false = only save credentials, don't connect


### PR DESCRIPTION
Added "WiFi.persistent(true);" to enable saving credentials to flash before setting WiFi credentials