### PR TITLE
Fix SNK MVS/AES sync regression (teardown loop + vertical jump)

### DIFF
--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -3438,7 +3438,8 @@ void doPostPresetLoadSteps()
         }
 
         if (rto->videoStandardInput == 1 || rto->videoStandardInput == 2) {
-            //GBS::PLLAD_ICP::write(5);         // 5 rather than 6 to work well with CVBS sync as well as CSync
+            GBS::PLLAD_ICP::write(3);            // TV5725 spec: ~296µA needed for 15.6kHz Hsync (SD interlaced/Csync)
+            latchPLLAD();
 
             GBS::ADC_FLTR::write(3);             // 5_03 4/5 ADC filter 3=40, 2=70, 1=110, 0=150 Mhz
             GBS::PLLAD_KS::write(2);             // 5_16
@@ -4741,7 +4742,7 @@ void updateSpDynamic(boolean withCurrentVideoModeCheck)
     if (rto->videoStandardInput != 0) {
         if (rto->videoStandardInput <= 2) { // SD interlaced
             GBS::SP_PRE_COAST::write(7);
-            GBS::SP_POST_COAST::write(3);
+            GBS::SP_POST_COAST::write(9); // pre-c364c0f value; 3 was too short for Csync re-lock after Vsync
             GBS::SP_DLT_REG::write(0xC0);     // old: 0x140 works better than 0x130 with psx
             GBS::SP_H_TIMER_VAL::write(0x28); // 5_33
 

--- a/gbs-control.ino
+++ b/gbs-control.ino
@@ -792,6 +792,7 @@ void setResetParameters()
     rto->osr = 0;
     rto->useHdmiSyncFix = 0;
     rto->notRecognizedCounter = 0;
+    rto->neoGeoCsyncLatched = false;
 
     adco->r_gain = 0;
     adco->g_gain = 0;
@@ -3438,7 +3439,7 @@ void doPostPresetLoadSteps()
         }
 
         if (rto->videoStandardInput == 1 || rto->videoStandardInput == 2) {
-            GBS::PLLAD_ICP::write(3);            // TV5725 spec: ~296µA needed for 15.6kHz Hsync (SD interlaced/Csync)
+            GBS::PLLAD_ICP::write(5);            // 5 rather than 6 to work well with CVBS sync as well as CSync (pre-37c3127 value); ICP=3 alone left chronic MVS dropouts on stock 24MHz clock
             latchPLLAD();
 
             GBS::ADC_FLTR::write(3);             // 5_03 4/5 ADC filter 3=40, 2=70, 1=110, 0=150 Mhz
@@ -4747,6 +4748,55 @@ void updateSpDynamic(boolean withCurrentVideoModeCheck)
             GBS::SP_H_TIMER_VAL::write(0x28); // 5_33
 
             if (rto->syncTypeCsync) {
+                // Neo Geo (MVS/AES) gate: 264 line progressive Csync without serration pulses.
+                // VPERIOD_IF reads 527/528 there; regular NTSC interlace maxes out at 526.
+                // The dynamic ignore length below (~0x62) swallows the ~2.3us transition pulses
+                // at the vsync region borders of that sync, making SDCS vsync separation bistable
+                // (+/-11 line vertical jumps). A small fixed ignore keeps those pulses visible.
+                //
+                // Sticky latch: some individual boards (AES) never report a solid PLLAD lock,
+                // which makes getVideoMode() flicker and re-enters this function far more often
+                // than usual. On a marginal-lock board, a single VPERIOD_IF read (+ 1 retry) can
+                // land outside the window purely from that jitter, not from an actual source
+                // change; falling through to the dynamic path on that lone miss is exactly what
+                // reintroduces the vertical jump it's meant to prevent.
+                //
+                // A miss is corroborated with STATUS_SYNC_PROC_VTOTAL (vt:) before releasing:
+                // on AES's VPERIOD_IF jitter, vt: stays pinned at 264 even while VPERIOD_IF reads
+                // garbage, but a real format change (eg switching to NTSC) moves vt: away from
+                // 264 immediately, together with VPERIOD_IF. Requiring both to disagree lets a
+                // real source change release on the very first miss (no held-over 0x04 bleeding
+                // into the new source), while a lone VPERIOD_IF misread with vt: still at 264 is
+                // treated as noise and keeps the gate latched.
+                uint16_t vPeriod = GBS::VPERIOD_IF::read();
+                if (vPeriod < 527 || vPeriod > 529) {
+                    delayMicroseconds(100);
+                    vPeriod = GBS::VPERIOD_IF::read(); // retry once, so the gate doesn't flap on a misread
+                }
+                if (vPeriod >= 527 && vPeriod <= 529) {
+                    if (!rto->neoGeoCsyncLatched || GBS::SP_H_PULSE_IGNOR::read() != 0x04) {
+                        rto->neoGeoCsyncLatched = true;
+                        GBS::SP_H_PULSE_IGNOR::write(0x04);
+                        rto->coastPositionIsSet = 0;
+                        SerialM.println(F("Csync without serration detected (Neo Geo): SP_H_PULSE_IGNOR fixed to 0x04"));
+                    }
+                    return;
+                }
+                if (rto->neoGeoCsyncLatched) {
+                    uint16_t vTotal = GBS::STATUS_SYNC_PROC_VTOTAL::read();
+                    if (vTotal >= 261 && vTotal <= 267) {
+                        // vt: still Neo Geo-like despite the VPERIOD_IF miss: noise, stay latched
+                        if (GBS::SP_H_PULSE_IGNOR::read() != 0x04) {
+                            GBS::SP_H_PULSE_IGNOR::write(0x04);
+                            rto->coastPositionIsSet = 0;
+                        }
+                        return;
+                    }
+                    // vt: corroborates a real format change: release the gate immediately
+                    rto->neoGeoCsyncLatched = false;
+                    SerialM.println(F("Neo Geo gate released (source no longer 264 line Csync)"));
+                }
+
                 uint16_t hPeriod = GBS::HPERIOD_IF::read();
                 for (int i = 0; i < 16; i++) {
                     if (hPeriod == 511 || hPeriod < 200) {
@@ -7307,6 +7357,7 @@ void setup()
     rto->osr = 0;
     rto->useHdmiSyncFix = 0;
     rto->notRecognizedCounter = 0;
+    rto->neoGeoCsyncLatched = false;
 
     // more run time variables
     rto->inputIsYpBpR = false;

--- a/options.h
+++ b/options.h
@@ -85,6 +85,7 @@ struct runTimeOptions
     bool isValidForScalingRGBHV;
     bool useHdmiSyncFix;
     bool extClockGenDetected;
+    bool neoGeoCsyncLatched; // sticky Neo Geo (MVS/AES) gate state, see updateSpDynamic()
 };
 // remember adc options across presets
 struct adcOptions


### PR DESCRIPTION
## Summary

Fixes two long-standing SNK MVS/AES sync regressions reported in #118 and #216: a
teardown loop (frequent freeze -> no signal -> re-detect) and a vertical jump
(picture shifts ~11 lines up/down every few seconds).

Root cause: Neo Geo's Csync is a 264-line progressive signal *without* the
serration/equalization pulses that regular NTSC/PAL have (confirmed against the
NeoDev wiki description and independent logic-analyzer capture). Two commits from
2019-2020 (targeting normal serrated NTSC/PAL, unaware of this) regressed MVS/AES
specifically:

- `PLLAD_ICP` fell back to 0 (<=60uA) after a `write(5)` call was commented out,
  well under the ~296uA the TV5725 spec calls for at 15.6kHz Hsync. Vsync-adjacent
  PLLAD re-lock became unreliable -> teardown loop.
- `SP_POST_COAST` was cut from 9 to 3, and the newly-introduced dynamic
  `SP_H_PULSE_IGNOR` calculation (correctly tuned for serrated signals) swallows
  the ~2.3us transition pulses at the edges of Neo Geo's malformed Vsync region.
  Losing those pulses makes SDCS vsync separation bistable -> vertical jump.

## Changes

1. **Restore `PLLAD_ICP=5` and `SP_POST_COAST=9`** for SD interlaced/Csync
   (mode 1/2), matching pre-regression values.
2. **Add a dedicated Neo Geo Csync gate** in `updateSpDynamic()`: when
   `VPERIOD_IF` reads 527-529 (Neo Geo's 264-line signal; regular NTSC interlace
   maxes out at 526) on a Csync source, fix `SP_H_PULSE_IGNOR=0x04` instead of
   running the dynamic calculation, keeping the transition pulses visible. The
   gate is latched sticky rather than re-evaluated every call, since AES boards
   with a marginal PLLAD lock flicker mode detection often enough that a single
   `VPERIOD_IF` misread could otherwise fall through to the dynamic path and
   reintroduce the jump; a miss is corroborated against
   `STATUS_SYNC_PROC_VTOTAL` (which stays pinned at 264 through the jitter, but
   moves immediately on a real format change) before releasing the latch.

## Testing

- Real MVS and AES hardware: no more vertical jump or teardown across extended
  sessions, including live MVS<->NTSC source switching (gate correctly
  releases/re-acquires, no bleed of the Neo Geo-specific ignore value into a
  newly connected NTSC/PAL source).
- A synthetic Csync generator (ESP32) producing `ntsc`/`pal`/`ps1`/`ps1pal`/
  `snes`/`palaes` signals: zero false positives on the gate, including
  serration-less-but-not-Neo-Geo (`snes`, 262 lines) and boundary-line-count
  (`ps1`, 263 lines) cases. `palaes` (PAL Neo Geo AES, 312 lines) falls outside
  the gate's `VPERIOD_IF` window and correctly falls through to the existing
  dynamic path, unaffected by this change (its serration-less Vsync still isn't
  handled, unchanged from before this PR — noted below).

## Known limitation

PAL AES (312 lines/50Hz) isn't covered by this gate, since its `VPERIOD_IF`
falls well outside the 527-529 window used to detect the 264-line NTSC-region
signal (window can't simply be widened: 312-313 lines is also the standard
range for ordinary 288p PAL sources). A serration-less-*detection* approach
(rather than line-count matching) would be needed to cover it; flagging as a
known gap rather than attempting it here.

## Build note

This PR only touches `gbs-control.ino` / `options.h` and applies cleanly on
current `master`. Unrelated to this fix: building `master` as-is currently fails
because the `me-no-dev/ESP Async WebServer@^1.2.3` PlatformIO registry entry is
gone; #551 already proposes a broader platformio/library modernization that
would cover this. I locally verified this PR's code builds and links cleanly
with the version bumps from that kind of fix applied on top (not included here
to keep this PR focused on the sync fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)